### PR TITLE
Pin Scala 3.3 LTS in scala steward

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -27,4 +27,6 @@ updates.pin = [
   # logback 1.3 and 1.4 would bump sfl4j to 2.0.0
   # http://mailman.qos.ch/pipermail/announce/2022/000177.html
   { groupId = "ch.qos.logback", artifactId = "logback-classic", version = "1.2." }
+  # Scala 3.3 is a LTS
+  { groupId = "org.scala-lang", artifactId = "scala3-library", version = "3.3." }
 ]


### PR DESCRIPTION
I noticed in Scala OS projects that Scala Steward has been bumping 3.3.x to 3.4.x