### PR TITLE
enable GrpcInteropIoWithPekkoHttpJavaSpec to work

### DIFF
--- a/interop-tests/src/test/scala/org/apache/pekko/grpc/interop/GrpcInteropSpec.scala
+++ b/interop-tests/src/test/scala/org/apache/pekko/grpc/interop/GrpcInteropSpec.scala
@@ -16,16 +16,23 @@ package org.apache.pekko.grpc.interop
 import io.grpc.testing.integration.TestServiceHandlerFactory
 
 class GrpcInteropIoWithIoSpec extends GrpcInteropTests(Servers.IoGrpc, Clients.IoGrpc)
+
 class GrpcInteropIoWithPekkoNettyScalaSpec extends GrpcInteropTests(Servers.IoGrpc, Clients.PekkoNetty.Scala)
 class GrpcInteropIoWithPekkoNettyScalaWithSslContextSpec
     extends GrpcInteropTests(Servers.IoGrpc, Clients.PekkoNetty.ScalaWithSslContext)
 class GrpcInteropIoWithPekkoNettyJavaSpec extends GrpcInteropTests(Servers.IoGrpc, Clients.PekkoNetty.Java)
+class GrpcInteropIoWithPekkoNettyJavaWithSslContextSpec
+    extends GrpcInteropTests(Servers.IoGrpc, Clients.PekkoNetty.JavaWithSslContext)
+
 class GrpcInteropIoWithPekkoHttpScalaSpec extends GrpcInteropTests(Servers.IoGrpc, Clients.PekkoHttp.Scala)
 class GrpcInteropIoWithPekkoHttpScalaWithSslContextSpec
     extends GrpcInteropTests(Servers.IoGrpc, Clients.PekkoHttp.ScalaWithSslContext)
 class GrpcInteropIoWithPekkoHttpJavaSpec extends GrpcInteropTests(Servers.IoGrpc, Clients.PekkoHttp.Java)
+class GrpcInteropIoWithPekkoHttpJavaWithSslContextSpec
+    extends GrpcInteropTests(Servers.IoGrpc, Clients.PekkoHttp.JavaWithSslContext)
 
 class GrpcInteropPekkoScalaWithIoSpec extends GrpcInteropTests(Servers.Pekko.Scala, Clients.IoGrpc)
+
 class GrpcInteropPekkoScalaWithPekkoNettyScalaSpec
     extends GrpcInteropTests(Servers.Pekko.Scala, Clients.PekkoNetty.Scala)
 class GrpcInteropPekkoScalaWithPekkoNettyJavaSpec extends GrpcInteropTests(Servers.Pekko.Scala, Clients.PekkoNetty.Java)
@@ -51,15 +58,16 @@ object Servers {
 object Clients {
   val IoGrpc = IoGrpcJavaClientProvider
   object PekkoNetty {
-    val Java = PekkoNettyClientProviderJava$
+    val Java = new PekkoClientProviderJava("netty", false)
     val Scala = new PekkoClientProviderScala("netty", false)
     val ScalaWithSslContext = new PekkoClientProviderScala("netty", true)
+    val JavaWithSslContext = new PekkoClientProviderJava("netty", true)
   }
   object PekkoHttp {
-    // FIXME: let's have Scala stable and we'll do Java later.
-    val Java = PekkoHttpClientProviderJava$
+    val Java = new PekkoClientProviderJava("pekko-http", false)
     val Scala = new PekkoClientProviderScala("pekko-http", false)
     val ScalaWithSslContext = new PekkoClientProviderScala("pekko-http", true)
+    val JavaWithSslContext = new PekkoClientProviderJava("pekko-http", true)
   }
 }
 
@@ -83,14 +91,9 @@ class PekkoClientProviderScala(backend: String, testWithSslContext: Boolean) ext
     implicit sys => new PekkoGrpcScalaClientTester(settings, backend, testWithSslContext))
 }
 
-object PekkoNettyClientProviderJava$ extends PekkoClientProvider {
+class PekkoClientProviderJava(backend: String, testWithSslContext: Boolean) extends PekkoClientProvider {
   val label: String = "pekko-grpc java client tester"
 
-  def client = new PekkoGrpcClientJava((settings, sys) => new PekkoGrpcJavaClientTester(settings, sys))
-}
-
-object PekkoHttpClientProviderJava$ extends PekkoClientProvider {
-  val label: String = "pekko-grpc java client tester"
-
-  def client = new PekkoGrpcClientJava((settings, sys) => new PekkoGrpcJavaClientTester(settings, sys))
+  def client = new PekkoGrpcClientJava((settings, sys) =>
+    new PekkoGrpcJavaClientTester(settings, sys, backend, testWithSslContext))
 }

--- a/interop-tests/src/test/scala/org/apache/pekko/grpc/interop/GrpcInteropSpec.scala
+++ b/interop-tests/src/test/scala/org/apache/pekko/grpc/interop/GrpcInteropSpec.scala
@@ -23,20 +23,20 @@ class GrpcInteropIoWithPekkoNettyJavaSpec extends GrpcInteropTests(Servers.IoGrp
 class GrpcInteropIoWithPekkoHttpScalaSpec extends GrpcInteropTests(Servers.IoGrpc, Clients.PekkoHttp.Scala)
 class GrpcInteropIoWithPekkoHttpScalaWithSslContextSpec
     extends GrpcInteropTests(Servers.IoGrpc, Clients.PekkoHttp.ScalaWithSslContext)
-//class GrpcInteropIoWithPekkoHttpJavaSpec extends GrpcInteropTests(Servers.IoGrpc, Clients.PekkoHttp.Java)
+class GrpcInteropIoWithPekkoHttpJavaSpec extends GrpcInteropTests(Servers.IoGrpc, Clients.PekkoHttp.Java)
 
 class GrpcInteropPekkoScalaWithIoSpec extends GrpcInteropTests(Servers.Pekko.Scala, Clients.IoGrpc)
 class GrpcInteropPekkoScalaWithPekkoNettyScalaSpec
     extends GrpcInteropTests(Servers.Pekko.Scala, Clients.PekkoNetty.Scala)
 class GrpcInteropPekkoScalaWithPekkoNettyJavaSpec extends GrpcInteropTests(Servers.Pekko.Scala, Clients.PekkoNetty.Java)
 class GrpcInteropPekkoScalaWithPekkoHttpScalaSpec extends GrpcInteropTests(Servers.Pekko.Scala, Clients.PekkoHttp.Scala)
-//class GrpcInteropPekkoScalaWithPekkoHttpJavaSpec extends GrpcInteropTests(Servers.Pekko.Scala, Clients.PekkoHttp.Java)
+class GrpcInteropPekkoScalaWithPekkoHttpJavaSpec extends GrpcInteropTests(Servers.Pekko.Scala, Clients.PekkoHttp.Java)
 
 class GrpcInteropPekkoJavaWithIoSpec extends GrpcInteropTests(Servers.Pekko.Java, Clients.IoGrpc)
 class GrpcInteropPekkoJavaWithPekkoNettyScalaSpec extends GrpcInteropTests(Servers.Pekko.Java, Clients.PekkoNetty.Scala)
 class GrpcInteropPekkoJavaWithPekkoNettyJavaSpec extends GrpcInteropTests(Servers.Pekko.Java, Clients.PekkoNetty.Java)
 class GrpcInteropPekkoJavaWithPekkoHttpScalaSpec extends GrpcInteropTests(Servers.Pekko.Java, Clients.PekkoHttp.Scala)
-//class GrpcInteropPekkoJavaWithPekkoHttpJavaSpec extends GrpcInteropTests(Servers.Pekko.Java, Clients.PekkoHttp.Java)
+class GrpcInteropPekkoJavaWithPekkoHttpJavaSpec extends GrpcInteropTests(Servers.Pekko.Java, Clients.PekkoHttp.Java)
 
 //--- Aliases
 
@@ -57,7 +57,7 @@ object Clients {
   }
   object PekkoHttp {
     // FIXME: let's have Scala stable and we'll do Java later.
-//    val Java = PekkoHttpClientProviderJava$
+    val Java = PekkoHttpClientProviderJava$
     val Scala = new PekkoClientProviderScala("pekko-http", false)
     val ScalaWithSslContext = new PekkoClientProviderScala("pekko-http", true)
   }
@@ -84,6 +84,12 @@ class PekkoClientProviderScala(backend: String, testWithSslContext: Boolean) ext
 }
 
 object PekkoNettyClientProviderJava$ extends PekkoClientProvider {
+  val label: String = "pekko-grpc java client tester"
+
+  def client = new PekkoGrpcClientJava((settings, sys) => new PekkoGrpcJavaClientTester(settings, sys))
+}
+
+object PekkoHttpClientProviderJava$ extends PekkoClientProvider {
   val label: String = "pekko-grpc java client tester"
 
   def client = new PekkoGrpcClientJava((settings, sys) => new PekkoGrpcJavaClientTester(settings, sys))


### PR DESCRIPTION
## motivation

close #204 

## changes
according to PekkoGrpcScalaClientTester
(1) add `backend` for `PekkoGrpcJavaClientTester` so that we can config 'pekko-http' and netty
(2) add `testWithSslContext` for `PekkoGrpcJavaClientTester` 


