### PR TITLE
remove guava upgrade hack

### DIFF
--- a/gradle-plugin/build.gradle
+++ b/gradle-plugin/build.gradle
@@ -127,7 +127,6 @@ repositories {
 dependencies {
   implementation 'com.google.protobuf:protobuf-gradle-plugin:0.9.4'
   implementation 'commons-lang:commons-lang:2.6'
-  runtimeOnly 'com.google.guava:guava:32.1.2-android'
   testImplementation 'junit:junit:4.13.2'
   testImplementation 'org.spockframework:spock-core:2.3-groovy-3.0'
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -56,15 +56,10 @@ object Dependencies {
     val scalapbRuntime = ("com.thesamet.scalapb" %% "scalapb-runtime" % scalapb.compiler.Version.scalapbVersion)
       .exclude("io.grpc", "grpc-netty")
 
-    // we force the use of a newer version of guava due to CVEs
-    val grpcCore = ("io.grpc" % "grpc-core" % Versions.grpc)
-      .excludeAll("com.google.guava" % "guava")
-    val grpcProtobuf = ("io.grpc" % "grpc-protobuf" % Versions.grpc)
-      .excludeAll("com.google.guava" % "guava")
-    val grpcNettyShaded = ("io.grpc" % "grpc-netty-shaded" % Versions.grpc)
-      .excludeAll("com.google.guava" % "guava")
-    val grpcStub = ("io.grpc" % "grpc-stub" % Versions.grpc)
-      .excludeAll("com.google.guava" % "guava")
+    val grpcCore = "io.grpc" % "grpc-core" % Versions.grpc
+    val grpcProtobuf = "io.grpc" % "grpc-protobuf" % Versions.grpc
+    val grpcNettyShaded = "io.grpc" % "grpc-netty-shaded" % Versions.grpc
+    val grpcStub = ("io.grpc" % "grpc-stub" % Versions.grpc
 
     // Excluding grpc-alts works around a complex resolution bug
     // Details are in https://github.com/akka/akka-grpc/pull/469
@@ -91,7 +86,6 @@ object Dependencies {
 
   object Runtime {
     val logback = "ch.qos.logback" % "logback-classic" % "1.3.14" % "runtime"
-    val guavaAndroid = "com.google.guava" % "guava" % "32.1.2-android" % "runtime"
   }
 
   object Protobuf {
@@ -109,7 +103,6 @@ object Dependencies {
     Compile.scalapbCompilerPlugin,
     Protobuf.protobufJava, // or else scalapb pulls older version in transitively
     Compile.grpcProtobuf,
-    Runtime.guavaAndroid, // forces a newer version than grpc-protobuf defaults too
     Test.scalaTest)
 
   lazy val runtime = l ++= Seq(
@@ -119,7 +112,6 @@ object Dependencies {
     Compile.grpcCore,
     Compile.grpcStub % Provided, // comes from the generators
     Compile.grpcNettyShaded,
-    Runtime.guavaAndroid, // forces a newer version than grpc-core/grpc-protobuf default too
     Compile.pekkoStream,
     Compile.pekkoHttpCore,
     Compile.pekkoHttp,
@@ -158,7 +150,6 @@ object Dependencies {
   lazy val pluginTester = l ++= Seq(
     // usually automatically added by `suggestedDependencies`, which doesn't work with ReflectiveCodeGen
     Compile.grpcStub,
-    Runtime.guavaAndroid,
     Compile.pekkoHttpCors,
     Compile.pekkoHttp,
     Test.scalaTest,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -59,7 +59,7 @@ object Dependencies {
     val grpcCore = "io.grpc" % "grpc-core" % Versions.grpc
     val grpcProtobuf = "io.grpc" % "grpc-protobuf" % Versions.grpc
     val grpcNettyShaded = "io.grpc" % "grpc-netty-shaded" % Versions.grpc
-    val grpcStub = ("io.grpc" % "grpc-stub" % Versions.grpc
+    val grpcStub = "io.grpc" % "grpc-stub" % Versions.grpc
 
     // Excluding grpc-alts works around a complex resolution bug
     // Details are in https://github.com/akka/akka-grpc/pull/469


### PR DESCRIPTION
the old guava version hack was down to Pekko-gRPC 1.0 and our attempt to use an out of date io.grpc jar but to use a newer guava jar because of a CVE in the old guava version

We now use up to date io.gprc jar so it will have a newer guava dependency.

See dependencies in https://mvnrepository.com/artifact/io.grpc/grpc-protobuf/1.62.2