### PR TITLE
add LoggingErrorHandlingGreeterClient with java

### DIFF
--- a/plugin-tester-java/src/main/java/example/myapp/helloworld/LoggingErrorHandlingGreeterClient.java
+++ b/plugin-tester-java/src/main/java/example/myapp/helloworld/LoggingErrorHandlingGreeterClient.java
@@ -1,10 +1,18 @@
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
- * license agreements; and to You under the Apache License, version 2.0:
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
  *
- *   https://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
- * This file is part of the Apache Pekko project, which was derived from Akka.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package example.myapp.helloworld;

--- a/plugin-tester-java/src/main/java/example/myapp/helloworld/LoggingErrorHandlingGreeterClient.java
+++ b/plugin-tester-java/src/main/java/example/myapp/helloworld/LoggingErrorHandlingGreeterClient.java
@@ -34,7 +34,6 @@ public class LoggingErrorHandlingGreeterClient {
 
     try {
       // #client-calls
-
       HelloRequest Martin = HelloRequest.newBuilder().setName("Martin").build();
       CompletionStage<HelloReply> successful = client.sayHello(Martin);
       successful.toCompletableFuture().get(10, TimeUnit.SECONDS);
@@ -65,7 +64,6 @@ public class LoggingErrorHandlingGreeterClient {
               })
           .toCompletableFuture()
           .get(10, TimeUnit.SECONDS);
-
       // #client-calls
     } catch (InterruptedException | ExecutionException | TimeoutException e) {
       throw new RuntimeException(e);

--- a/plugin-tester-java/src/main/java/example/myapp/helloworld/LoggingErrorHandlingGreeterClient.java
+++ b/plugin-tester-java/src/main/java/example/myapp/helloworld/LoggingErrorHandlingGreeterClient.java
@@ -43,11 +43,12 @@ public class LoggingErrorHandlingGreeterClient {
       HelloRequest martin = HelloRequest.newBuilder().setName("martin").build();
       CompletionStage<HelloReply> failedBecauseLowercase = client.sayHello(martin);
       failedBecauseLowercase
-          .whenComplete(
+          .handle(
               (response, exception) -> {
                 if (exception != null) {
                   sys.log().info("Call with lowercase name failed");
                 }
+                return response;
               })
           .toCompletableFuture()
           .get(10, TimeUnit.SECONDS);
@@ -55,11 +56,12 @@ public class LoggingErrorHandlingGreeterClient {
       HelloRequest empty = HelloRequest.newBuilder().setName("").build();
       CompletionStage<HelloReply> failedBecauseEmpty = client.sayHello(empty);
       failedBecauseEmpty
-          .whenComplete(
+          .handle(
               (response, exception) -> {
                 if (exception != null) {
                   sys.log().info("Call with empty name failed");
                 }
+                return response;
               })
           .toCompletableFuture()
           .get(10, TimeUnit.SECONDS);

--- a/plugin-tester-java/src/main/java/example/myapp/helloworld/LoggingErrorHandlingGreeterClient.java
+++ b/plugin-tester-java/src/main/java/example/myapp/helloworld/LoggingErrorHandlingGreeterClient.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, which was derived from Akka.
+ */
+
+package example.myapp.helloworld;
+
+import example.myapp.helloworld.grpc.GreeterServiceClient;
+import example.myapp.helloworld.grpc.HelloReply;
+import example.myapp.helloworld.grpc.HelloRequest;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import org.apache.pekko.actor.ActorSystem;
+import org.apache.pekko.grpc.GrpcClientSettings;
+
+public class LoggingErrorHandlingGreeterClient {
+
+  public static void main(String[] args) {
+
+    // Boot pekko
+    ActorSystem sys = ActorSystem.create("LoggingErrorHandlingGreeterClient");
+
+    // Take details how to connect to the service from the config.
+    GrpcClientSettings clientSettings =
+        GrpcClientSettings.connectToServiceAt("127.0.0.1", 8082, sys).withTls(false);
+    // Create a client-side stub for the service
+    GreeterServiceClient client = GreeterServiceClient.create(clientSettings, sys);
+
+    try {
+      // #client-calls
+
+      HelloRequest Martin = HelloRequest.newBuilder().setName("Martin").build();
+      CompletionStage<HelloReply> successful = client.sayHello(Martin);
+      successful.toCompletableFuture().get(10, TimeUnit.SECONDS);
+      sys.log().info("Call succeeded");
+
+      HelloRequest martin = HelloRequest.newBuilder().setName("martin").build();
+      CompletionStage<HelloReply> failedBecauseLowercase = client.sayHello(martin);
+      failedBecauseLowercase
+          .whenComplete(
+              (response, exception) -> {
+                if (exception != null) {
+                  sys.log().info("Call with lowercase name failed");
+                }
+              })
+          .toCompletableFuture()
+          .get(10, TimeUnit.SECONDS);
+
+      HelloRequest empty = HelloRequest.newBuilder().setName("").build();
+      CompletionStage<HelloReply> failedBecauseEmpty = client.sayHello(empty);
+      failedBecauseEmpty
+          .whenComplete(
+              (response, exception) -> {
+                if (exception != null) {
+                  sys.log().info("Call with empty name failed");
+                }
+              })
+          .toCompletableFuture()
+          .get(10, TimeUnit.SECONDS);
+
+      // #client-calls
+    } catch (InterruptedException | ExecutionException | TimeoutException e) {
+      throw new RuntimeException(e);
+    }
+    sys.terminate();
+  }
+}

--- a/plugin-tester-java/src/main/java/example/myapp/helloworld/LoggingErrorHandlingGreeterClient.java
+++ b/plugin-tester-java/src/main/java/example/myapp/helloworld/LoggingErrorHandlingGreeterClient.java
@@ -33,7 +33,6 @@ public class LoggingErrorHandlingGreeterClient {
     GreeterServiceClient client = GreeterServiceClient.create(clientSettings, sys);
 
     try {
-      // #client-calls
       HelloRequest Martin = HelloRequest.newBuilder().setName("Martin").build();
       CompletionStage<HelloReply> successful = client.sayHello(Martin);
       successful.toCompletableFuture().get(10, TimeUnit.SECONDS);
@@ -64,7 +63,6 @@ public class LoggingErrorHandlingGreeterClient {
               })
           .toCompletableFuture()
           .get(10, TimeUnit.SECONDS);
-      // #client-calls
     } catch (InterruptedException | ExecutionException | TimeoutException e) {
       throw new RuntimeException(e);
     }


### PR DESCRIPTION
# motivation
in module `plugin-tester-scala`
there are `LoggingErrorHandlingGreeterServer` and `LoggingErrorHandlingGreeterClient`
but in moulde `plugin-tester-java`
there is not a `LoggingErrorHandlingGreeterClient`
# resutle
add  LoggingErrorHandlingGreeterClient with java
NOW, we run a Scala-server, use java-client to sayHello, interesting play with it.
