### PR TITLE
Investigate a frequently flaky CI failure in GrpcExceptionHandlerSpec

### DIFF
--- a/docs/src/main/paradox/server/details.md
+++ b/docs/src/main/paradox/server/details.md
@@ -30,7 +30,7 @@ For an overview of gRPC status codes and their meaning see [statuscodes.md](http
 For unary responses:
 
 Scala
-:    @@snip[GrpcExceptionHandlerSpec](/interop-tests/src/test/scala/org/apache/pekko/grpc/scaladsl/GrpcExceptionHandlerSpec.scala) { #unary }
+:    @@snip[GrpcExceptionDefaultHandleSpec](/interop-tests/src/test/scala/org/apache/pekko/grpc/scaladsl/GrpcExceptionDefaultHandleSpec.scala) { #unary }
 
 Java
 :   @@snip[ExceptionGreeterServiceImpl](/interop-tests/src/test/java/example/myapp/helloworld/grpc/ExceptionGreeterServiceImpl.java) { #unary }
@@ -38,7 +38,7 @@ Java
 For streaming responses:
 
 Scala
-:    @@snip[GrpcExceptionHandlerSpec](/interop-tests/src/test/scala/org/apache/pekko/grpc/scaladsl/GrpcExceptionHandlerSpec.scala) { #streaming }
+:    @@snip[GrpcExceptionDefaultHandleSpec](/interop-tests/src/test/scala/org/apache/pekko/grpc/scaladsl/GrpcExceptionDefaultHandleSpec.scala) { #streaming }
 
 Java
 :   @@snip[ExceptionGreeterServiceImpl](/interop-tests/src/test/java/example/myapp/helloworld/grpc/ExceptionGreeterServiceImpl.java) { #streaming }

--- a/interop-tests/src/test/scala/org/apache/pekko/grpc/scaladsl/GrpcExceptionDefaultHandleSpec.scala
+++ b/interop-tests/src/test/scala/org/apache/pekko/grpc/scaladsl/GrpcExceptionDefaultHandleSpec.scala
@@ -31,7 +31,7 @@ import org.scalatest.wordspec.AnyWordSpecLike
 
 import scala.concurrent.{ ExecutionContext, Future }
 
-class GrpcExceptionHandlerSpec
+class GrpcExceptionDefaultHandleSpec
     extends TestKit(ActorSystem("GrpcExceptionHandlerSpec"))
     with AnyWordSpecLike
     with Matchers

--- a/interop-tests/src/test/scala/org/apache/pekko/grpc/scaladsl/GrpcExceptionDefaultHandleSpec.scala
+++ b/interop-tests/src/test/scala/org/apache/pekko/grpc/scaladsl/GrpcExceptionDefaultHandleSpec.scala
@@ -32,7 +32,7 @@ import org.scalatest.wordspec.AnyWordSpecLike
 import scala.concurrent.{ ExecutionContext, Future }
 
 class GrpcExceptionDefaultHandleSpec
-    extends TestKit(ActorSystem("GrpcExceptionHandlerSpec"))
+    extends TestKit(ActorSystem("GrpcExceptionDefaultHandleSpec"))
     with AnyWordSpecLike
     with Matchers
     with ScalaFutures {

--- a/runtime/src/test/scala/org/apache/pekko/grpc/scaladsl/GrpcExceptionHandlerSpec.scala
+++ b/runtime/src/test/scala/org/apache/pekko/grpc/scaladsl/GrpcExceptionHandlerSpec.scala
@@ -48,10 +48,10 @@ class GrpcExceptionHandlerSpec extends AnyWordSpec with Matchers with ScalaFutur
 
   val otherTypes: Seq[Throwable] = Seq(
     new GrpcServiceException(status = Status.DEADLINE_EXCEEDED),
-    new NotImplementedError,
-    new UnsupportedOperationException,
-    new NullPointerException,
-    new RuntimeException,
+    new NotImplementedError(),
+    new UnsupportedOperationException(),
+    new NullPointerException(),
+    new RuntimeException(),
     new StatusRuntimeException(io.grpc.Status.DEADLINE_EXCEEDED))
 
   val executionExceptions: Seq[Throwable] =


### PR DESCRIPTION
## motivation
close #291 

maybe : there are 2 file-name(class) used GrpcExceptionHandlerSpec with same package
and `new NullPointerException` shoulde be `new NullPointerException()`