### PR TITLE
share trailers through matval

### DIFF
--- a/runtime/src/main/scala/org/apache/pekko/grpc/internal/PekkoNettyGrpcClientGraphStage.scala
+++ b/runtime/src/main/scala/org/apache/pekko/grpc/internal/PekkoNettyGrpcClientGraphStage.scala
@@ -112,7 +112,9 @@ private final class PekkoNettyGrpcClientGraphStage[I, O](
           callback.invoke(message)
 
         override def onClose(status: Status, trailers: Metadata): Unit = {
-          onHeaders(trailers)
+          if (!matVal.isCompleted) {
+            onHeaders(trailers)
+          }
           callback.invoke(Closed(status))
         }
       }

--- a/runtime/src/main/scala/org/apache/pekko/grpc/internal/PekkoNettyGrpcClientGraphStage.scala
+++ b/runtime/src/main/scala/org/apache/pekko/grpc/internal/PekkoNettyGrpcClientGraphStage.scala
@@ -13,15 +13,15 @@
 
 package org.apache.pekko.grpc.internal
 
+import io.grpc._
 import org.apache.pekko
 import pekko.annotation.InternalApi
 import pekko.dispatch.ExecutionContexts
-import pekko.grpc.{ GrpcResponseMetadata, GrpcServiceException }
+import pekko.grpc.GrpcResponseMetadata
 import pekko.stream
 import pekko.stream.{ Attributes => _, _ }
 import pekko.stream.stage._
 import pekko.util.FutureConverters._
-import io.grpc._
 
 import scala.concurrent.{ Future, Promise }
 import scala.util.Success
@@ -179,8 +179,8 @@ private final class PekkoNettyGrpcClientGraphStage[I, O](
           completeStage()
         } else {
           matVal.future.onComplete {
-            case Success(metadata) => failStage(new GrpcServiceException(status, metadata.headers))
-            case _                 => failStage(new GrpcServiceException(status))
+            case Success(metadata) => failStage(status.asRuntimeException(metadata.headers.raw.orNull))
+            case _                 => failStage(status.asRuntimeException())
           }(ExecutionContexts.parasitic)
         }
         call = null


### PR DESCRIPTION
# motivation
close #302 
share trailers through matval
# how 
- remove usage of `val trailerPromise = Promise[Metadata]()`
- use pekko metadata instead of grpc-java metadata
- will throw `class GrpcServiceException(val status: Status, val metadata: Metadata)
    extends StatusRuntimeException(status, metadata.raw.orNull) ` instead of StatusRuntimeException (grpc-java)