### PR TITLE
fix binary trailer decoding

### DIFF
--- a/runtime/src/test/scala/org/apache/pekko/grpc/internal/PekkoHttpClientUtilsSpec.scala
+++ b/runtime/src/test/scala/org/apache/pekko/grpc/internal/PekkoHttpClientUtilsSpec.scala
@@ -66,8 +66,8 @@ class PekkoHttpClientUtilsSpec extends TestKit(ActorSystem()) with AnyWordSpecLi
       val responseHeaders = List(RawHeader("grpc-status", "9"))
       val responseTrailers = Trailer(
         RawHeader("custom-key", "custom-trailer-value") ::
-          RawHeader("custom-key-bin", ByteString("custom-trailer-value").encodeBase64.utf8String) ::
-          Nil)
+        RawHeader("custom-key-bin", ByteString("custom-trailer-value").encodeBase64.utf8String) ::
+        Nil)
       val response = Future.successful(
         new HttpResponse(
           OK,


### PR DESCRIPTION
In #230 I introduced a bug in the trailer decoding where I didn't take into consideration that there are "ASCII headers" and "binary headers"