### PR TITLE
build with pekko 1.1 jars

### DIFF
--- a/plugin-tester-java/build.gradle
+++ b/plugin-tester-java/build.gradle
@@ -29,9 +29,9 @@ def scalaVersion = org.gradle.util.VersionNumber.parse(scalaFullVersion)
 def scalaBinaryVersion = "${scalaVersion.major}.${scalaVersion.minor}"
 
 dependencies {
-  implementation group: 'org.apache.pekko', name: "pekko-http-cors_${scalaBinaryVersion}", version: '1.0.0'
+  implementation "org.apache.pekko:pekko-http-cors_${scalaBinaryVersion}:1.1.0-M1"
   implementation "org.scala-lang:scala-library:${scalaFullVersion}"
-  testImplementation "org.apache.pekko:pekko-stream-testkit_${scalaBinaryVersion}:1.0.2"
+  testImplementation "org.apache.pekko:pekko-stream-testkit_${scalaBinaryVersion}:1.1.0-M1"
   testImplementation "org.scalatest:scalatest_${scalaBinaryVersion}:3.2.18"
   testImplementation "org.scalatestplus:junit-4-13_${scalaBinaryVersion}:3.2.18.0"
 }

--- a/plugin-tester-java/pom.xml
+++ b/plugin-tester-java/pom.xml
@@ -24,7 +24,7 @@
     <maven.compiler.target>1.8</maven.compiler.target>
     <maven-dependency-plugin.version>3.1.2</maven-dependency-plugin.version>
     <maven-exec-plugin.version>3.0.0</maven-exec-plugin.version>
-    <pekko.http.version>1.0.1</pekko.http.version>
+    <pekko.http.version>1.1.0-M1</pekko.http.version>
     <grpc.version>1.64.0</grpc.version> <!-- checked synced by VersionSyncCheckPlugin -->
     <project.encoding>UTF-8</project.encoding>
   </properties>

--- a/plugin-tester-scala/build.gradle
+++ b/plugin-tester-scala/build.gradle
@@ -24,9 +24,9 @@ def scalaVersion = org.gradle.util.VersionNumber.parse(scalaFullVersion)
 def scalaBinaryVersion = "${scalaVersion.major}.${scalaVersion.minor}"
 
 dependencies {
-  implementation group: 'org.apache.pekko', name: "pekko-http-cors_${scalaBinaryVersion}", version: '1.0.0'
+  implementation "org.apache.pekko:pekko-http-cors_${scalaBinaryVersion}:1.1.0-M1"
   implementation "org.scala-lang:scala-library:${scalaFullVersion}"
-  testImplementation "org.apache.pekko:pekko-stream-testkit_${scalaBinaryVersion}:1.0.2"
+  testImplementation "org.apache.pekko:pekko-stream-testkit_${scalaBinaryVersion}:1.1.0-M1"
   testImplementation "org.scalatest:scalatest_${scalaBinaryVersion}:3.2.18"
   testImplementation "org.scalatestplus:junit-4-13_${scalaBinaryVersion}:3.2.18.0"
 }

--- a/plugin-tester-scala/pom.xml
+++ b/plugin-tester-scala/pom.xml
@@ -22,8 +22,8 @@
   <properties>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
-    <pekko.version>1.0.2</pekko.version>
-    <pekko.http.version>1.0.1</pekko.http.version>
+    <pekko.version>1.1.0-M1</pekko.version>
+    <pekko.http.version>1.1.0-M1</pekko.http.version>
     <grpc.version>1.64.0</grpc.version> <!-- checked synced by VersionSyncCheckPlugin -->
     <project.encoding>UTF-8</project.encoding>
   </properties>

--- a/project/PekkoCoreDependency.scala
+++ b/project/PekkoCoreDependency.scala
@@ -22,5 +22,5 @@ import com.github.pjfanning.pekkobuild.PekkoDependency
 object PekkoCoreDependency extends PekkoDependency {
   override val checkProject: String = "pekko-cluster-sharding-typed"
   override val module: Option[String] = None
-  override val currentVersion: String = "1.0.2"
+  override val currentVersion: String = "1.1.0-M1"
 }

--- a/project/PekkoHttpDependency.scala
+++ b/project/PekkoHttpDependency.scala
@@ -22,5 +22,5 @@ import com.github.pjfanning.pekkobuild.PekkoDependency
 object PekkoHttpDependency extends PekkoDependency {
   override val checkProject: String = "pekko-http-testkit"
   override val module: Option[String] = Some("http")
-  override val currentVersion: String = "1.0.1"
+  override val currentVersion: String = "1.1.0-M1"
 }


### PR DESCRIPTION
Aim to have all Pekko Modules in their 1.1 branches use 1.1 Pekko dependencies.