### PR TITLE
non-https links now in license page

### DIFF
--- a/scripts/link-validator.conf
+++ b/scripts/link-validator.conf
@@ -44,6 +44,7 @@ site-link-validator {
     "http://commons.apache.org/proper/",
     "http://findbugs.sourceforge.net/",
     "http://fusesource.github.io/jansi",
+    "http://github.com/typelevel/jawn"
     "http://hc.apache.org/",
     "http://hdrhistogram.github.io/HdrHistogram/",
     "http://jcp.org/en/jsr/detail?id=250",
@@ -66,5 +67,6 @@ site-link-validator {
     "http://www.slf4j.org",
     "http://creativecommons.org/"
     "http://jopt-simple.github.io/"
+    "http://jspecify.org/"
   ]
 }


### PR DESCRIPTION
https://github.com/apache/pekko-grpc/actions/runs/10341534635/job/28623448570?pr=354

We've got no control over what goes in that page.