### PR TITLE
in CI, don't specify full scala version

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -65,7 +65,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        SCALA_VERSION: [2.12.19, 2.13.14, 3.3.3]
+        SCALA_VERSION: [2.12, 2.13, 3.3]
         JAVA_VERSION: [8, 11, 17, 21]
     steps:
       - name: Checkout


### PR DESCRIPTION
* makes CI maintenance easier
* the sbt files have the full scala versions specified