### PR TITLE
scala 2.13.15 and 3.3.4

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -65,7 +65,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        SCALA_VERSION: [2.12.20, 2.13.14, 3.3.3]
+        SCALA_VERSION: [2.12.20, 2.13.15, 3.3.3]
         JAVA_VERSION: [8, 11, 17, 21]
     steps:
       - name: Checkout

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -65,7 +65,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        SCALA_VERSION: [2.12.20, 2.13.15, 3.3.3]
+        SCALA_VERSION: [2.12.20, 2.13.15, 3.3.4]
         JAVA_VERSION: [8, 11, 17, 21]
     steps:
       - name: Checkout

--- a/.github/workflows/publish-nightly.yml
+++ b/.github/workflows/publish-nightly.yml
@@ -27,7 +27,7 @@ jobs:
         run: |-
           cp .jvmopts-ci .jvmopts
           sbt +publish
-          sbt ++2.13.14! codegen/publish
+          sbt ++2.13.15! codegen/publish
           sbt ++3.3.3! codegen/publish
         env:
           NEXUS_USER: ${{ secrets.NEXUS_USER }}

--- a/.github/workflows/publish-nightly.yml
+++ b/.github/workflows/publish-nightly.yml
@@ -28,7 +28,7 @@ jobs:
           cp .jvmopts-ci .jvmopts
           sbt +publish
           sbt ++2.13.15! codegen/publish
-          sbt ++3.3.3! codegen/publish
+          sbt ++3.3.4! codegen/publish
         env:
           NEXUS_USER: ${{ secrets.NEXUS_USER }}
           NEXUS_PW: ${{ secrets.NEXUS_PW }}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -17,7 +17,7 @@ object Dependencies {
   object Versions {
     // Update the .github workflows when these scala versions change
     val scala212 = "2.12.20"
-    val scala213 = "2.13.14"
+    val scala213 = "2.13.15"
     val scala3 = "3.3.3"
 
     // the order in the list is important because the head will be considered the default.

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -18,7 +18,7 @@ object Dependencies {
     // Update the .github workflows when these scala versions change
     val scala212 = "2.12.20"
     val scala213 = "2.13.15"
-    val scala3 = "3.3.3"
+    val scala3 = "3.3.4"
 
     // the order in the list is important because the head will be considered the default.
     val CrossScalaForLib = Seq(scala212, scala213, scala3)


### PR DESCRIPTION
seems ok to upgrade now

build issues are just in link-validator and those issues are explainable (gnu.org is offline and lightbemd.com page works but link-validator seems to be having issues with it in a few builds) 