### PR TITLE
grpc 1.68.1

### DIFF
--- a/benchmark-java/build.sbt
+++ b/benchmark-java/build.sbt
@@ -14,7 +14,7 @@ run / javaOptions ++= List("-Xms1g", "-Xmx1g", "-XX:+PrintGCDetails", "-XX:+Prin
 // generate both client and server (default) in Java
 pekkoGrpcGeneratedLanguages := Seq(PekkoGrpc.Java)
 
-val grpcVersion = "1.67.1" // checked synced by VersionSyncCheckPlugin
+val grpcVersion = "1.68.1" // checked synced by VersionSyncCheckPlugin
 
 val runtimeProject = ProjectRef(file("../"), "runtime")
 

--- a/gradle-plugin/src/main/groovy/org/apache/pekko/grpc/gradle/PekkoGrpcPluginExtension.groovy
+++ b/gradle-plugin/src/main/groovy/org/apache/pekko/grpc/gradle/PekkoGrpcPluginExtension.groovy
@@ -18,7 +18,7 @@ class PekkoGrpcPluginExtension {
 
     static final String PROTOC_PLUGIN_SCALA_VERSION = "2.12"
 
-    static final String GRPC_VERSION = "1.67.1" // checked synced by VersionSyncCheckPlugin
+    static final String GRPC_VERSION = "1.68.1" // checked synced by VersionSyncCheckPlugin
 
     static final String PLUGIN_CODE = 'org.apache.pekko.grpc.gradle'
 

--- a/plugin-tester-java/pom.xml
+++ b/plugin-tester-java/pom.xml
@@ -25,7 +25,7 @@
     <maven-dependency-plugin.version>3.1.2</maven-dependency-plugin.version>
     <maven-exec-plugin.version>3.0.0</maven-exec-plugin.version>
     <pekko.http.version>1.1.0</pekko.http.version>
-    <grpc.version>1.67.1</grpc.version> <!-- checked synced by VersionSyncCheckPlugin -->
+    <grpc.version>1.68.1</grpc.version> <!-- checked synced by VersionSyncCheckPlugin -->
     <project.encoding>UTF-8</project.encoding>
   </properties>
 

--- a/plugin-tester-scala/pom.xml
+++ b/plugin-tester-scala/pom.xml
@@ -24,7 +24,7 @@
     <maven.compiler.target>1.8</maven.compiler.target>
     <pekko.version>1.1.2</pekko.version>
     <pekko.http.version>1.1.0</pekko.http.version>
-    <grpc.version>1.67.1</grpc.version> <!-- checked synced by VersionSyncCheckPlugin -->
+    <grpc.version>1.68.1</grpc.version> <!-- checked synced by VersionSyncCheckPlugin -->
     <project.encoding>UTF-8</project.encoding>
   </properties>
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -32,7 +32,7 @@ object Dependencies {
     val pekkoHttp = PekkoHttpDependency.version
     val pekkoHttpBinary = pekkoHttp.take(3)
 
-    val grpc = "1.67.1" // checked synced by VersionSyncCheckPlugin
+    val grpc = "1.68.1" // checked synced by VersionSyncCheckPlugin
     // Even referenced explicitly in the sbt-plugin's sbt-tests
     // If changing this, remember to update protoc plugin version to align in
     // maven-plugin/src/main/maven/plugin.xml and org.apache.pekko.grpc.sbt.PekkoGrpcPlugin

--- a/runtime/src/main/scala/org/apache/pekko/grpc/internal/PekkoDiscoveryNameResolver.scala
+++ b/runtime/src/main/scala/org/apache/pekko/grpc/internal/PekkoDiscoveryNameResolver.scala
@@ -52,7 +52,8 @@ class PekkoDiscoveryNameResolver(
   def lookup(listener: Listener): Unit = {
     import scala.concurrent.Await
     try {
-      val result = Await.result(discovery.lookup(Lookup(serviceName, portName, protocol), resolveTimeout), resolveTimeout)
+      val result =
+        Await.result(discovery.lookup(Lookup(serviceName, portName, protocol), resolveTimeout), resolveTimeout)
       listener.onAddresses(addresses(result.addresses), Attributes.EMPTY)
     } catch {
       case e: Throwable =>

--- a/runtime/src/main/scala/org/apache/pekko/grpc/internal/PekkoDiscoveryNameResolver.scala
+++ b/runtime/src/main/scala/org/apache/pekko/grpc/internal/PekkoDiscoveryNameResolver.scala
@@ -50,16 +50,12 @@ class PekkoDiscoveryNameResolver(
     }
 
   def lookup(listener: Listener): Unit = {
-    discovery.lookup(Lookup(serviceName, portName, protocol), resolveTimeout).onComplete {
-      case Success(result) =>
-        try {
-          listener.onAddresses(addresses(result.addresses), Attributes.EMPTY)
-        } catch {
-          case e: UnknownHostException =>
-            // TODO at least log
-            listener.onError(Status.UNKNOWN.withDescription(e.getMessage))
-        }
-      case Failure(e) =>
+    import scala.concurrent.Await
+    try {
+      val result = Await.result(discovery.lookup(Lookup(serviceName, portName, protocol), resolveTimeout), resolveTimeout)
+      listener.onAddresses(addresses(result.addresses), Attributes.EMPTY)
+    } catch {
+      case e: Throwable =>
         // TODO at least log
         listener.onError(Status.UNKNOWN.withDescription(e.getMessage))
     }

--- a/sbt-plugin/src/sbt-test/gen-scala-server/00-interop/build.sbt
+++ b/sbt-plugin/src/sbt-test/gen-scala-server/00-interop/build.sbt
@@ -13,7 +13,7 @@ scalaVersion := "2.12.20"
 
 organization := "org.apache.pekko"
 
-val grpcVersion = "1.67.1" // checked synced by VersionSyncCheckPlugin
+val grpcVersion = "1.68.1" // checked synced by VersionSyncCheckPlugin
 
 libraryDependencies ++= Seq(
   "io.grpc" % "grpc-interop-testing" % grpcVersion % "protobuf-src",


### PR DESCRIPTION
* try to workaround issues in #397 by not updating the grpc name-resolver listener in a Scala future
* there are some issues even after this - similar issues with grpc 1.68.1 enforcing that SynchronizationContext is used and that fails because we use Scala Futures
* https://github.com/grpc/grpc-java/issues/11662 I suspect the changes in grpc 1.68.1 are too big for us to workaround and that we might need to get grpc team to allow config to disable some of their recent changes