### PR TITLE
use Pekko JavaConverter

### DIFF
--- a/runtime/src/main/scala/org/apache/pekko/grpc/SSLContextUtils.scala
+++ b/runtime/src/main/scala/org/apache/pekko/grpc/SSLContextUtils.scala
@@ -22,7 +22,7 @@ import javax.net.ssl.{ TrustManager, TrustManagerFactory }
 object SSLContextUtils {
   def trustManagerFromStream(certStream: InputStream): TrustManager = {
     try {
-      import scala.collection.JavaConverters._
+      import org.apache.pekko.util.ccompat.JavaConverters._
       val cf = CertificateFactory.getInstance("X.509")
       val bis = new BufferedInputStream(certStream)
 

--- a/runtime/src/main/scala/org/apache/pekko/grpc/internal/Codecs.scala
+++ b/runtime/src/main/scala/org/apache/pekko/grpc/internal/Codecs.scala
@@ -32,7 +32,7 @@ object Codecs {
       case sReq: sm.HttpMessage =>
         sReq.headers
       case _ =>
-        import scala.collection.JavaConverters._
+        import pekko.util.ccompat.JavaConverters._
         request.getHeaders.asScala
     }
   }

--- a/runtime/src/main/scala/org/apache/pekko/grpc/internal/MetadataImpl.scala
+++ b/runtime/src/main/scala/org/apache/pekko/grpc/internal/MetadataImpl.scala
@@ -15,13 +15,13 @@ package org.apache.pekko.grpc.internal
 
 import java.util.{ List => jList, Locale, Map => jMap, Optional }
 
-import scala.collection.JavaConverters._
 import scala.collection.immutable
 import org.apache.pekko
 import pekko.annotation.InternalApi
 import pekko.http.scaladsl.model.HttpHeader
 import pekko.japi.Pair
 import pekko.util.ByteString
+import pekko.util.ccompat.JavaConverters._
 import pekko.grpc.scaladsl.{ BytesEntry, Metadata, MetadataEntry, StringEntry }
 import pekko.grpc.javadsl
 import pekko.util.OptionConverters._

--- a/runtime/src/main/scala/org/apache/pekko/grpc/internal/PekkoDiscoveryNameResolver.scala
+++ b/runtime/src/main/scala/org/apache/pekko/grpc/internal/PekkoDiscoveryNameResolver.scala
@@ -67,7 +67,7 @@ class PekkoDiscoveryNameResolver(
 
   @throws[UnknownHostException]
   private def addresses(addresses: Seq[ResolvedTarget]) = {
-    import scala.collection.JavaConverters._
+    import pekko.util.ccompat.JavaConverters._
     addresses
       .map(target => {
         val port = target.port.getOrElse(defaultPort)

--- a/runtime/src/main/scala/org/apache/pekko/grpc/internal/ServerReflectionImpl.scala
+++ b/runtime/src/main/scala/org/apache/pekko/grpc/internal/ServerReflectionImpl.scala
@@ -18,12 +18,12 @@ import org.apache.pekko
 import pekko.NotUsed
 import pekko.annotation.InternalApi
 import pekko.stream.scaladsl._
+import pekko.util.ccompat.JavaConverters._
 import _root_.grpc.reflection.v1alpha.reflection._
 import com.google.protobuf.ByteString
 
 import java.util.concurrent.ConcurrentHashMap
 import scala.collection.concurrent
-import collection.JavaConverters._
 
 /**
  * INTERNAL API
@@ -77,7 +77,7 @@ final class ServerReflectionImpl private (fileDescriptors: Map[String, FileDescr
  */
 @InternalApi
 object ServerReflectionImpl {
-  import scala.collection.JavaConverters._
+  import pekko.util.ccompat.JavaConverters._
 
   def apply(fileDescriptors: Seq[FileDescriptor], services: List[String]): ServerReflectionImpl = {
     val fileDescriptorsWithDeps = (ReflectionProto.javaDescriptor +: fileDescriptors).toSet.flatMap(flattenDependencies)

--- a/runtime/src/main/scala/org/apache/pekko/grpc/javadsl/MetadataBuilder.scala
+++ b/runtime/src/main/scala/org/apache/pekko/grpc/javadsl/MetadataBuilder.scala
@@ -18,7 +18,7 @@ import java.lang.{ Iterable => jIterable }
 import org.apache.pekko
 import pekko.annotation.ApiMayChange
 
-import scala.collection.JavaConverters._
+import pekko.util.ccompat.JavaConverters._
 import pekko.http.javadsl.model.HttpHeader
 import pekko.http.scaladsl.model.{ HttpHeader => sHttpHeader }
 import pekko.http.scaladsl.model.headers.RawHeader

--- a/runtime/src/main/scala/org/apache/pekko/grpc/javadsl/ServerReflection.scala
+++ b/runtime/src/main/scala/org/apache/pekko/grpc/javadsl/ServerReflection.scala
@@ -31,7 +31,7 @@ object ServerReflection {
   def create(
       objects: Collection[ServiceDescription],
       sys: ClassicActorSystemProvider): pekko.japi.function.Function[HttpRequest, CompletionStage[HttpResponse]] = {
-    import scala.collection.JavaConverters._
+    import pekko.util.ccompat.JavaConverters._
     val delegate = ServerReflectionHandler.apply(
       ServerReflectionImpl(objects.asScala.map(_.descriptor).toSeq, objects.asScala.map(_.name).toList))(sys)
     import pekko.util.FutureConverters._

--- a/runtime/src/main/scala/org/apache/pekko/grpc/javadsl/WebHandler.scala
+++ b/runtime/src/main/scala/org/apache/pekko/grpc/javadsl/WebHandler.scala
@@ -75,7 +75,7 @@ object WebHandler {
       as: ClassicActorSystemProvider,
       mat: Materializer,
       corsSettings: CorsSettings): JFunction[HttpRequest, CompletionStage[HttpResponse]] = {
-    import scala.collection.JavaConverters._
+    import pekko.util.ccompat.JavaConverters._
 
     val servicesHandler = concatOrNotFound(handlers.asScala.toList: _*)
     val servicesRoute = RouteAdapter(MarshallingDirectives.handleWith(servicesHandler.apply(_)))

--- a/runtime/src/main/scala/org/apache/pekko/grpc/scaladsl/headers/headers.scala
+++ b/runtime/src/main/scala/org/apache/pekko/grpc/scaladsl/headers/headers.scala
@@ -45,7 +45,7 @@ object `Message-Accept-Encoding` extends ModeledCustomHeaderCompanion[`Message-A
 
   /** Java API */
   def findIn(headers: java.lang.Iterable[jm.HttpHeader]): Array[String] = {
-    import scala.collection.JavaConverters._
+    import pekko.util.ccompat.JavaConverters._
     findIn(headers.asScala)
   }
 }
@@ -70,7 +70,7 @@ object `Message-Encoding` extends ModeledCustomHeaderCompanion[`Message-Encoding
 
   /** Java API */
   def findIn(headers: java.lang.Iterable[jm.HttpHeader]): Option[String] = {
-    import scala.collection.JavaConverters._
+    import pekko.util.ccompat.JavaConverters._
     findIn(headers.asScala)
   }
 }

--- a/runtime/src/test/scala/org/apache/pekko/grpc/internal/NameResolverListenerProbe.scala
+++ b/runtime/src/test/scala/org/apache/pekko/grpc/internal/NameResolverListenerProbe.scala
@@ -15,7 +15,8 @@ package org.apache.pekko.grpc.internal
 
 import java.util
 
-import org.apache.pekko.grpc.GrpcServiceException
+import org.apache.pekko
+import pekko.grpc.GrpcServiceException
 import io.grpc.{ Attributes, EquivalentAddressGroup, NameResolver, Status }
 
 import scala.concurrent.Promise
@@ -24,7 +25,7 @@ class NameResolverListenerProbe extends NameResolver.Listener {
   private val promise = Promise[Seq[EquivalentAddressGroup]]()
 
   override def onAddresses(servers: util.List[EquivalentAddressGroup], attributes: Attributes): Unit = {
-    import scala.collection.JavaConverters._
+    import pekko.util.ccompat.JavaConverters._
     promise.trySuccess(servers.asScala.toSeq)
   }
 

--- a/runtime/src/test/scala/org/apache/pekko/grpc/internal/PekkoDiscoveryNameResolverProviderSpec.scala
+++ b/runtime/src/test/scala/org/apache/pekko/grpc/internal/PekkoDiscoveryNameResolverProviderSpec.scala
@@ -71,7 +71,7 @@ class PekkoDiscoveryNameResolverProviderSpec
       val addressGroupsPromise = Promise[List[EquivalentAddressGroup]]()
       val listener = new Listener() {
         override def onAddresses(addresses: JList[EquivalentAddressGroup], attributes: Attributes): Unit = {
-          import scala.collection.JavaConverters._
+          import pekko.util.ccompat.JavaConverters._
           addressGroupsPromise.success(addresses.asScala.toList)
         }
         override def onError(error: io.grpc.Status): Unit = ???

--- a/runtime/src/test/scala/org/apache/pekko/grpc/internal/PekkoDiscoveryNameResolverSpec.scala
+++ b/runtime/src/test/scala/org/apache/pekko/grpc/internal/PekkoDiscoveryNameResolverSpec.scala
@@ -25,7 +25,7 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatest.time.{ Millis, Seconds, Span }
 import org.scalatest.wordspec.AnyWordSpecLike
 
-import scala.collection.JavaConverters._
+import pekko.util.ccompat.JavaConverters._
 import scala.concurrent.ExecutionContext
 
 class PekkoDiscoveryNameResolverSpec


### PR DESCRIPTION
* just updated the 'runtime' module
* other modules don't necessarily have a dependency on pekko-actor module so can't use Pekko JavaConverter unless we add a dependency - I'd prefer not to do this