### PR TITLE
tidy up imports

### DIFF
--- a/maven-plugin/src/main/scala/org/apache/pekko/grpc/maven/AbstractGenerateMojo.scala
+++ b/maven-plugin/src/main/scala/org/apache/pekko/grpc/maven/AbstractGenerateMojo.scala
@@ -120,7 +120,6 @@ abstract class AbstractGenerateMojo @Inject() (buildContext: BuildContext) exten
   @BeanProperty
   var generatePlayServer: Boolean = _
 
-  import scala.collection.JavaConverters._
   @BeanProperty
   var generatorSettings: java.util.Map[String, String] = _
 
@@ -179,6 +178,7 @@ abstract class AbstractGenerateMojo @Inject() (buildContext: BuildContext) exten
     if (schemas.isEmpty) {
       getLog.info("No changed or new .proto-files found in [%s], skipping code generation".format(generatedSourcesDir))
     } else {
+      import scala.collection.JavaConverters._
       val loadedExtraGenerators =
         extraGenerators.asScala.map(cls =>
           Class.forName(cls).getDeclaredConstructor().newInstance().asInstanceOf[CodeGenerator])


### PR DESCRIPTION
* `asScala` is used in 2 places
    - in one case, we add a locally scoped import on Scala JavaConverters
    - in the other case, we have a globally scoped import on Scala JavaConverters but in the middle of the class
* I've moved the globally scoped one to be local to the 2nd use of `asScala`