### PR TITLE
plugin-tester-scala: set protoc version

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -289,6 +289,7 @@ lazy val pluginTesterScala = Project(id = "plugin-tester-scala", base = file("pl
   .settings(
     name := s"$pekkoPrefix-plugin-tester-scala",
     fork := true,
+    PB.protocVersion := Dependencies.Versions.googleProtoc,
     crossScalaVersions := Dependencies.Versions.CrossScalaForLib,
     scalaVersion := scala212,
     ReflectiveCodeGen.codeGeneratorSettings ++= Seq("flat_package", "server_power_apis"))


### PR DESCRIPTION
see #404 - plugin-tester-java and interop-tests set this - so best to be consistent