### PR TITLE
[WIP] Assembly jar LICENSE/NOTICE

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -49,6 +49,7 @@ lazy val codegen = Project(id = "codegen", base = file("codegen"))
   .disablePlugins(MimaPlugin)
   .settings(Dependencies.codegen)
   .settings(resolvers += Resolver.sbtPluginRepo("releases"))
+  .settings(MetaInfLicenseNoticeCopy.assemblySettings)
   .settings(
     name := s"$pekkoPrefix-codegen",
     mkBatAssemblyTask := {
@@ -73,7 +74,7 @@ lazy val codegen = Project(id = "codegen", base = file("codegen"))
     (assembly / assemblyMergeStrategy) := {
       case PathList("META-INF", "MANIFEST.MF")                      => MergeStrategy.discard
       case PathList("META-INF", "versions", _, "module-info.class") => MergeStrategy.discard
-      case "LICENSE" | "NOTICE"                                     => MergeStrategy.discard
+      case "LICENSE" | "LICENSE.txt" | "NOTICE"                     => MergeStrategy.discard
       case _                                                        => MergeStrategy.deduplicate
     },
     crossScalaVersions := Dependencies.Versions.CrossScalaForPlugin,
@@ -121,6 +122,7 @@ lazy val runtime = Project(id = "runtime", base = file("runtime"))
 val pekkoGrpcProtocPluginId = s"$pekkoPrefix-scalapb-protoc-plugin"
 lazy val scalapbProtocPlugin = Project(id = "scalapb-protoc-plugin", base = file("scalapb-protoc-plugin"))
   .disablePlugins(MimaPlugin)
+  .settings(MetaInfLicenseNoticeCopy.assemblySettings)
   .settings(
     name := s"$pekkoPrefix-scalapb-protoc-plugin",
     libraryDependencies += {
@@ -140,7 +142,7 @@ lazy val scalapbProtocPlugin = Project(id = "scalapb-protoc-plugin", base = file
     (assembly / assemblyMergeStrategy) := {
       case PathList("META-INF", "MANIFEST.MF")                      => MergeStrategy.discard
       case PathList("META-INF", "versions", _, "module-info.class") => MergeStrategy.discard
-      case "LICENSE" | "NOTICE"                                     => MergeStrategy.discard
+      case "LICENSE" | "LICENSE.txt" | "NOTICE"                     => MergeStrategy.discard
       case _                                                        => MergeStrategy.deduplicate
     })  
   .settings(

--- a/build.sbt
+++ b/build.sbt
@@ -71,8 +71,10 @@ lazy val codegen = Project(id = "codegen", base = file("codegen"))
     (assembly / assemblyOption) := (assembly / assemblyOption).value.withPrependShellScript(
       Some(sbtassembly.AssemblyPlugin.defaultUniversalScript(shebang = true))),
     (assembly / assemblyMergeStrategy) := {
-      case PathList("META-INF", _*) => MergeStrategy.discard
-      case _                        => MergeStrategy.deduplicate
+      case PathList("META-INF", "MANIFEST.MF")                      => MergeStrategy.discard
+      case PathList("META-INF", "versions", _, "module-info.class") => MergeStrategy.discard
+      case "LICENSE" | "NOTICE"                                     => MergeStrategy.discard
+      case _                                                        => MergeStrategy.deduplicate
     },
     crossScalaVersions := Dependencies.Versions.CrossScalaForPlugin,
     scalaVersion := scala212,
@@ -134,7 +136,13 @@ lazy val scalapbProtocPlugin = Project(id = "scalapb-protoc-plugin", base = file
     },
     (assembly / mainClass) := Some("org.apache.pekko.grpc.scalapb.Main"),
     (assembly / assemblyOption) := (assembly / assemblyOption).value.withPrependShellScript(
-      Some(sbtassembly.AssemblyPlugin.defaultUniversalScript(shebang = true))))
+      Some(sbtassembly.AssemblyPlugin.defaultUniversalScript(shebang = true))),
+    (assembly / assemblyMergeStrategy) := {
+      case PathList("META-INF", "MANIFEST.MF")                      => MergeStrategy.discard
+      case PathList("META-INF", "versions", _, "module-info.class") => MergeStrategy.discard
+      case "LICENSE" | "NOTICE"                                     => MergeStrategy.discard
+      case _                                                        => MergeStrategy.deduplicate
+    })  
   .settings(
     crossScalaVersions := Dependencies.Versions.CrossScalaForLib,
     scalaVersion := Dependencies.Versions.CrossScalaForLib.head)

--- a/legal/AssemblyLicense.txt
+++ b/legal/AssemblyLicense.txt
@@ -1,0 +1,205 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+---------------
+
+TODO add dependency licenses

--- a/legal/AssemblyLicense.txt
+++ b/legal/AssemblyLicense.txt
@@ -202,4 +202,57 @@
 
 ---------------
 
-TODO add dependency licenses
+The pekko-grpc-codegen and pekko-grpc-scalapb-protoc-plugin assembly jars and
+bat archives contain classes from 3rd party projects.
+
+Apache License Version 2.0:
+
+com.thesamet.scalapb:compilerplugin
+com.thesamet.scalapb:protoc-gen
+com.thesamet.scalapb:protoc-bridge
+io.grpc:grpc-api
+io.grpc:grpc-protobuf
+io.grpc:grpc-protobuf-lite
+org.checkerframework:checker-qual
+org.playframework.twirl:twirl-api
+org.scala-lang:scala-library
+org.scala-lang:scala3-library
+org.scala-lang.modules:scala-collection-compat
+org.scala-lang.modules:scala-xml
+
+----
+
+Checker Framework qualifiers
+Copyright 2004-present by the Checker Framework developers
+
+MIT License:
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+----
+
+com.google.api.grpc:proto-google-common-protos:2.41.0
+com.google.protobuf:protobuf-java
+com.google.code.findbugs:jsr305
+com.google.errorprone:error_prone_annotations
+com.google.guava:guava
+com.google.guava:failureaccess
+com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-..
+com.google.j2objc:j2objc-annotations
+dev.dirs:directories

--- a/legal/AssemblyNotice.txt
+++ b/legal/AssemblyNotice.txt
@@ -1,0 +1,231 @@
+Apache Pekko gRPC
+Copyright 2022-2024 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (https://www.apache.org/).
+
+This product contains significant parts that were originally based on software from Lightbend (Akka <https://akka.io/>).
+Copyright (C) 2009-2022 Lightbend Inc. <https://www.lightbend.com>
+
+Apache Pekko gRPC is derived from Akka gRPC 2.1.x, the last version that was distributed under the
+Apache License, Version 2.0 License.
+
+---------------
+
+The pekko-grpc-codegen and pekko-grpc-scalapb-protoc-plugin assembly jars and
+bat archives contain classes from 3rd party projects. Some of these projects
+have NOTICE files - included below.
+
+---------------
+
+grpc-api, grpc-protobuf, grpc-protobuf-lite
+
+Copyright 2014 The gRPC Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+-----------------------------------------------------------------------
+
+This product contains a modified portion of 'OkHttp', an open source
+HTTP & SPDY client for Android and Java applications, which can be obtained
+at:
+
+  * LICENSE:
+    * okhttp/third_party/okhttp/LICENSE (Apache License 2.0)
+  * HOMEPAGE:
+    * https://github.com/square/okhttp
+  * LOCATION_IN_GRPC:
+    * okhttp/third_party/okhttp
+
+This product contains a modified portion of 'Envoy', an open source
+cloud-native high-performance edge/middle/service proxy, which can be
+obtained at:
+
+  * LICENSE:
+    * xds/third_party/envoy/LICENSE (Apache License 2.0)
+  * NOTICE:
+    * xds/third_party/envoy/NOTICE
+  * HOMEPAGE:
+    * https://www.envoyproxy.io
+  * LOCATION_IN_GRPC:
+    * xds/third_party/envoy
+
+This product contains a modified portion of 'protoc-gen-validate (PGV)',
+an open source protoc plugin to generate polyglot message validators,
+which can be obtained at:
+
+  * LICENSE:
+    * xds/third_party/protoc-gen-validate/LICENSE (Apache License 2.0)
+  * NOTICE:
+      * xds/third_party/protoc-gen-validate/NOTICE
+  * HOMEPAGE:
+    * https://github.com/envoyproxy/protoc-gen-validate
+  * LOCATION_IN_GRPC:
+    * xds/third_party/protoc-gen-validate
+
+This product contains a modified portion of 'udpa',
+an open source universal data plane API, which can be obtained at:
+
+  * LICENSE:
+    * xds/third_party/udpa/LICENSE (Apache License 2.0)
+  * HOMEPAGE:
+    * https://github.com/cncf/udpa
+  * LOCATION_IN_GRPC:
+    * xds/third_party/udpa
+
+---------------
+
+scala-library and scala-xml
+Copyright (c) 2002-2024 EPFL
+Copyright (c) 2011-2024 Lightbend, Inc.
+
+Scala includes software developed at
+LAMP/EPFL (https://lamp.epfl.ch/) and
+Lightbend, Inc. (https://www.lightbend.com/).
+
+Licensed under the Apache License, Version 2.0 (the "License").
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+---------------
+
+scala-collection-compat
+Copyright (c) 2002-2023 EPFL
+Copyright (c) 2011-2023 Lightbend, Inc.
+
+Scala includes software developed at
+LAMP/EPFL (https://lamp.epfl.ch/) and
+Lightbend, Inc. (https://www.lightbend.com/).
+
+Licensed under the Apache License, Version 2.0 (the "License").
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+---------------
+
+scala3-library
+
+Dotty (https://dotty.epfl.ch)
+Copyright 2012-2024 EPFL
+Copyright 2012-2024 Lightbend, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"):
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+The dotty compiler frontend has been developed since November 2012 by Martin
+Odersky. It is expected and hoped for that the list of contributors to the
+codebase will grow quickly. Dotty draws inspiration and code from the original
+Scala compiler "nsc", which is developed at scala/scala [1].
+
+The majority of the dotty codebase is new code, with the exception of the
+components mentioned below. We have for each component tried to come up with a
+list of the original authors in the scala/scala [1] codebase. Apologies if some
+major authors were omitted by oversight.
+
+  * dotty.tools.dotc.ast: The syntax tree handling is mostly new, but some
+    elements, such as the idea of tree copiers and the `TreeInfo` module,
+    were adopted from scala/scala [1]. The original authors of these parts
+    include Martin Odersky, Paul Phillips, Adriaan Moors, and Matthias Zenger.
+
+  * dotty.tools.dotc.classpath: The classpath handling is taken mostly as is
+    from scala/scala [1]. The original authors were Grzegorz Kossakowski,
+    Michał Pociecha, Lukas  Rytz, Jason Zaugg and others.
+
+  * dotty.tools.dotc.config: The configuration components were adapted and
+    extended from scala/scala [1]. The original sources were authored by Paul
+    Phillips with contributions from Martin Odersky, Miguel Garcia and others.
+
+  * dotty.tools.dotc.core: The core data structures and operations are mostly
+    new. Some parts (e.g. those dealing with names) were adapted from
+    scala/scala [1]. These were originally authored by Martin Odersky, Adriaan
+    Moors, Jason Zaugg, Paul Phillips, Eugene Burmako and others.
+
+  * dotty.tools.dotc.core.pickling: The classfile readers were adapted from the
+    current Scala compiler. Original authors were Martin Odersky, Iulian
+    Dragos, Matthias Zenger and others.
+
+  * dotty.tools.dotc.parsing: The lexical and syntactic analysis components
+    were adapted from the current Scala compiler. They were originally authored
+    by Martin Odersky, Burak Emir, Paul Phillips, Lex Spoon, Sean McDirmid and
+    others.
+
+  * dotty.tools.dotc.profile: The per-phase profiling support is taken mostly
+    as is from scala/scala. The original author was Mike Skells.
+
+  * dotty.tools.dotc.reporting: Adapted from scala/scala [1] with some heavy
+    modifications. They were originally authored by Matthias Zenger, Martin
+    Odersky, and others.
+
+  * dotty.tools.dotc.typer: This is new code except for some minor components
+    (e.g. the ConstantFolder). It uses however many solution details that have
+    been developed over time by many people, including Jason Zaugg, Adriaan
+    Moors, Lukas Rytz, Paul Phillips, Grzegorz Kossakowski, and others.
+
+  * dotty.tools.dotc.util: The utilities package is a mix of new and adapted
+    components. The files in scala/scala [1] were originally authored by many
+    people, including Paul Phillips, Martin Odersky, Sean McDirmid, and others.
+
+  * dotty.tools.io: The I/O support library was adapted from current Scala
+    compiler. Original authors were Paul Phillips and others.
+
+  * dotty.test.DottyBytecodeTest: Is an adaptation of the bytecode testing from
+    scala/scala [1]. It has been reworked to fit the needs of dotty. Original
+    authors include: Adrian Moors, Lukas Rytz, Grzegorz Kossakowski, Paul
+    Phillips.
+
+  * dotty.tools.dotc.sbt and everything in sbt-bridge: The sbt compiler phases
+    are based on [2] which attempts to integrate the sbt phases into scalac and
+    is itself based on the compiler bridge in sbt 0.13 [3], but has been
+    heavily adapted and refactored. Original authors were Mark Harrah, Grzegorz
+    Kossakowski, Martin Duhemm, Adriaan Moors and others.
+
+  * dotty.tools.dotc.plugins: Adapted from scala/scala [1] with some
+    modifications. They were originally authored by Lex Spoon, Som Snytt,
+    Adriaan Moors, Paul Phillips and others.
+
+  * dotty.tools.scaladoc: The Scaladoc documentation utility ships some
+    third-party JavaScript and CSS libraries which are located under
+    scaladoc/resources/dotty_res/styles/, scaladoc/resources/dotty_res/scripts/, docs/css/ and
+    docs/js/. Please refer to the license header of the concerned files for
+    details.
+
+  * dotty.tools.dotc.coverage: Coverage instrumentation utilities have been
+    adapted from the scoverage plugin for scala 2 [4], which is under the
+    Apache 2.0 license.
+
+  * dooty.tools.pc: Presentation compiler implementation adapted from
+    scalameta/metals [5] mtags module, which is under the Apache 2.0 license.
+
+  * The Dotty codebase contains parts which are derived from
+    the ScalaPB protobuf library [6], which is under the Apache 2.0 license.
+
+
+[1] https://github.com/scala/scala
+[2] https://github.com/adriaanm/scala/tree/sbt-api-consolidate/src/compiler/scala/tools/sbt
+[3] https://github.com/sbt/sbt/tree/0.13/compile/interface/src/main/scala/xsbt
+[4] https://github.com/scoverage/scalac-scoverage-plugin
+[5] https://github.com/scalameta/metals
+[6] https://github.com/scala/scala3/pull/5783/files
+

--- a/project/MetaInfLicenseNoticeCopy.scala
+++ b/project/MetaInfLicenseNoticeCopy.scala
@@ -18,7 +18,7 @@
 import sbt.Keys._
 import sbt._
 import org.mdedetrich.apache.sonatype.ApacheSonatypePlugin
-import ApacheSonatypePlugin.autoImport.{ apacheSonatypeDisclaimerFile, apacheSonatypeLicenseFile }
+import ApacheSonatypePlugin.autoImport.{ apacheSonatypeLicenseFile, apacheSonatypeNoticeFile }
 
 /**
  * Copies LICENSE and NOTICE files into jar META-INF dir
@@ -37,4 +37,8 @@ object MetaInfLicenseNoticeCopy extends AutoPlugin {
   lazy val runtimeSettings = Seq(
     apacheSonatypeLicenseFile := baseDir.value / "legal" / "RuntimeLicense.txt")
 
+  lazy val assemblySettings = Seq(
+    apacheSonatypeLicenseFile := baseDir.value / "legal" / "AssemblyLicense.txt",
+    apacheSonatypeNoticeFile := baseDir.value / "legal" / "AssemblyNotice.txt")
+  
 }


### PR DESCRIPTION
see #411 

Work in Progress. I still need to update the details for some dependencies.

Unfortunately, sbt-assembly does not appear to support adding extra files so the simplest seems to be change the LICENSE/NOTICE in the module jar and those will also appear in the assembly jars.