### PR TITLE
trailer only response for immediate stream failures

### DIFF
--- a/.sbtopts
+++ b/.sbtopts
@@ -1,3 +1,0 @@
--J-Xmx8G
--J-Xms8G
--J-XX:+UseG1GC

--- a/.sbtopts
+++ b/.sbtopts
@@ -1,0 +1,3 @@
+-J-Xmx8G
+-J-Xms8G
+-J-XX:+UseG1GC

--- a/benchmarks/src/main/scala/org/apache/pekko/grpc/GrpcMarshallingBenchmark.scala
+++ b/benchmarks/src/main/scala/org/apache/pekko/grpc/GrpcMarshallingBenchmark.scala
@@ -22,6 +22,9 @@ import pekko.stream.scaladsl.Source
 import grpc.reflection.v1alpha.reflection._
 import org.openjdk.jmh.annotations._
 
+import scala.concurrent.Await
+import scala.concurrent.duration.DurationInt
+
 // Microbenchmarks for GrpcMarshalling.
 // Does not actually benchmarks the actual marshalling because we dont consume the HttpResponse
 class GrpcMarshallingBenchmark extends CommonBenchmark {
@@ -38,7 +41,7 @@ class GrpcMarshallingBenchmark extends CommonBenchmark {
 
   @Benchmark
   def marshallStream(): HttpResponse = {
-    GrpcMarshalling.marshalStream(Source.repeat(ServerReflectionRequest()).take(10000))
+    Await.result(GrpcMarshalling.marshalStream(Source.repeat(ServerReflectionRequest()).take(10000)), 1.second)
   }
 
   @TearDown

--- a/codegen/src/main/twirl/templates/JavaServer/Handler.scala.txt
+++ b/codegen/src/main/twirl/templates/JavaServer/Handler.scala.txt
@@ -171,7 +171,7 @@ public class @{serviceName}HandlerFactory {
           case "@method.grpcName":
             response = @{method.unmarshal}(request.entity(), @method.deserializer.name, mat, reader)
               .@{if(method.outputStreaming) { "thenApply" } else { "thenCompose" }}(e -> implementation.@{method.name}(e@{if(powerApis) { ", metadata" } else { "" }}))
-              .thenApply(e -> @{method.marshal}(e, @method.serializer.name, writer, system, eHandler));
+              .@{if(method.outputStreaming) { "thenCompose" } else { "thenApply" }}(e -> @{method.marshal}(e, @method.serializer.name, writer, system, eHandler));
             break;
           }
           default:

--- a/codegen/src/main/twirl/templates/ScalaCommon/Marshallers.scala.txt
+++ b/codegen/src/main/twirl/templates/ScalaCommon/Marshallers.scala.txt
@@ -26,6 +26,7 @@ import pekko.grpc.ProtobufSerializer
 import pekko.grpc.scaladsl.GrpcMarshalling
 import pekko.grpc.scaladsl.ScalapbProtobufSerializer
 import pekko.http.scaladsl.marshalling.Marshaller
+import pekko.http.scaladsl.marshalling.Marshalling
 import pekko.http.scaladsl.marshalling.ToResponseMarshaller
 import pekko.http.scaladsl.model.HttpRequest
 import pekko.http.scaladsl.unmarshalling.FromRequestUnmarshaller
@@ -49,5 +50,12 @@ object @{service.name}Marshallers {
     Marshaller.opaque((response: T) => GrpcMarshalling.marshal(response)(serializer, writer, system))
 
   implicit def fromSourceMarshaller[T](implicit serializer: ProtobufSerializer[T], writer: GrpcProtocolWriter, system: ClassicActorSystemProvider): ToResponseMarshaller[pekko.stream.scaladsl.Source[T, pekko.NotUsed]] =
-    Marshaller.opaque((response: pekko.stream.scaladsl.Source[T, pekko.NotUsed]) => GrpcMarshalling.marshalStream(response)(serializer, writer, system))
+    Marshaller[
+      pekko.stream.scaladsl.Source[T, pekko.NotUsed],
+      pekko.http.scaladsl.model.HttpResponse
+    ](ec =>
+      response =>
+        GrpcMarshalling.marshalStream(response)(serializer, writer, system)
+          .map(response => Marshalling.Opaque(() => response) :: Nil)(ec)
+    )
 }

--- a/codegen/src/main/twirl/templates/ScalaServer/Handler.scala.txt
+++ b/codegen/src/main/twirl/templates/ScalaServer/Handler.scala.txt
@@ -131,7 +131,7 @@ object @{serviceName}Handler {
                 @{if(powerApis) { "val metadata = MetadataBuilder.fromHeaders(request.headers)" } else { "" }}
                 @{method.unmarshal}(request.entity)(@method.deserializer.name, mat, reader)
                   .@{if(method.outputStreaming) { "map" } else { "flatMap" }}(implementation.@{method.nameSafe}(_@{if(powerApis) { ", metadata" } else { "" }}))
-                  .map(e => @{method.marshal}(e, eHandler)(@method.serializer.name, writer, system))
+                  .@{if(method.outputStreaming) { "flatMap" } else { "map" }}(e => @{method.marshal}(e, eHandler)(@method.serializer.name, writer, system))
             }
             case m => scala.concurrent.Future.failed(new NotImplementedError(s"Not implemented: $m"))
           })

--- a/interop-tests/src/test/scala/org/apache/pekko/grpc/scaladsl/GrpcExceptionDefaultHandleSpec.scala
+++ b/interop-tests/src/test/scala/org/apache/pekko/grpc/scaladsl/GrpcExceptionDefaultHandleSpec.scala
@@ -172,14 +172,14 @@ class GrpcExceptionDefaultHandleSpec
 
       val reply = GreeterServiceHandler(ExampleImpl).apply(request).futureValue
 
-      val lastChunk = reply.entity.asInstanceOf[Chunked].chunks.runWith(Sink.last).futureValue.asInstanceOf[LastChunk]
+      val trailer = reply.headers
       // Invalid argument is '3' https://github.com/grpc/grpc/blob/master/doc/statuscodes.md
-      val statusHeader = lastChunk.trailer.find { _.name == "grpc-status" }
+      val statusHeader = trailer.find { _.name == "grpc-status" }
       statusHeader.map(_.value()) should be(Some("3"))
-      val statusMessageHeader = lastChunk.trailer.find { _.name == "grpc-message" }
+      val statusMessageHeader = trailer.find { _.name == "grpc-message" }
       statusMessageHeader.map(_.value()) should be(Some("No name found"))
 
-      val metadata = MetadataBuilder.fromHeaders(lastChunk.trailer)
+      val metadata = MetadataBuilder.fromHeaders(trailer)
       metadata.getText("test-text") should be(Some("test-text-data"))
       metadata.getBinary("test-binary-bin") should be(Some(ByteString("test-binary-data")))
     }

--- a/interop-tests/src/test/scala/org/apache/pekko/grpc/scaladsl/PowerApiSpec.scala
+++ b/interop-tests/src/test/scala/org/apache/pekko/grpc/scaladsl/PowerApiSpec.scala
@@ -106,8 +106,10 @@ abstract class PowerApiSpec(backend: String)
             complete(
               GrpcResponseHelpers(
                 Source.single(HelloReply("Hello there!")),
-                trail = Source.single(GrpcEntityHelpers.trailer(Status.OK, trailingMetadata)))
-                .addHeader(RawHeader("baz", "qux")))
+                trail = Source.single(GrpcEntityHelpers.trailer(Status.OK, trailingMetadata))
+              )
+                .map(_.addHeader(RawHeader("baz", "qux")))(system.dispatcher)
+            )
           })
           .futureValue
 
@@ -163,7 +165,7 @@ abstract class PowerApiSpec(backend: String)
             implicit val writer: GrpcProtocol.GrpcProtocolWriter = GrpcProtocolNative.newWriter(Identity)
             complete(
               GrpcResponseHelpers(Source.single(HelloReply("Hello there!")), trail = Source.future(trailer.future))
-                .addHeader(RawHeader("foo", "bar")))
+                .map(_.addHeader(RawHeader("foo", "bar")))(system.dispatcher))
           })
           .futureValue
 

--- a/runtime/src/main/scala/org/apache/pekko/grpc/scaladsl/GrpcMarshalling.scala
+++ b/runtime/src/main/scala/org/apache/pekko/grpc/scaladsl/GrpcMarshalling.scala
@@ -104,7 +104,7 @@ object GrpcMarshalling {
       eHandler: ActorSystem => PartialFunction[Throwable, Trailers] = GrpcExceptionHandler.defaultMapper)(
       implicit m: ProtobufSerializer[T],
       writer: GrpcProtocolWriter,
-      system: ClassicActorSystemProvider): HttpResponse = {
+      system: ClassicActorSystemProvider): Future[HttpResponse] = {
     GrpcResponseHelpers(e, eHandler)
   }
 
@@ -127,5 +127,4 @@ object GrpcMarshalling {
       writer: GrpcProtocolWriter,
       system: ClassicActorSystemProvider): HttpRequest =
     GrpcRequestHelpers(uri, List.empty, e, eHandler)
-
 }


### PR DESCRIPTION
**Problem**: In server-side streaming, the status 200/initial headers are sent as soon as the RPC is invoked.
If the first pull immediately fails, the error is then send as a trailer. But the headers were already on the wire, which isn't the suggested [gRPC §4.1.1 “Trailers-Only”] contract. This confuses a number of proxies.

**Fix**: Hold the response until we’ve seen at least one element.
- Success path: wait for first element → flush normal headers → emit first element → stream continues → normal trailers.
- Failure after emitting at least one element:  wait for first element → flush normal headers → emit the first element contact with zero or more elements → failure happens, send failure in trailers
- Failure before first element: no headers → send a single HEADERS frame with grpc-status != 0 (trailers-only).

To apply this fix I had to change the signature for `GrpcMarshalling.marshalStream` which is used for code-gen. 


Expected (no proxy)
```bash
grpcurl . -proto fruitapi.proto -d '{}' redacted-no-proxy:443 io.reverie.fruitapi.FruitAPI/GetFruits
```
```
ERROR:
  Code: ResourceExhausted
  Message: Ran out of fruits :(
  Details:
  1)    {
          "@error": "google.rpc.ResourceInfo is not recognized; see @value for raw binary message data",
          "@type": "type.googleapis.com/google.rpc.ResourceInfo",
          "@value": "CgVGcnVpdBIQaW8ucmV2ZXJpZS5GcnVpdBoKaW8ucmV2ZXJpZSIcYXBwbGVzLCBiYW5hbmFzLCBhbmQgb3Jhbmdlcw=="
        }
```

Reality (with proxy)
```bash
grpcurl -v -import-path . -proto fruitapi.proto -d '{}' redacted.io:443 io.reverie.fruitapi.FruitAPI/GetFruits
```
Which is behind a proxy emits headers with content-length: 0, and then a trailer, which gets swallowed.

```
Resolved method descriptor:
rpc GetFruits ( .io.reverie.fruitapi.GetFruitRequest ) returns ( stream .io.reverie.fruitapi.GetFruitResponse );

Request metadata to send:
authorization: Bearer <REDACTED>

Response headers received:
(empty)

Response trailers received:
content-length: 0
content-type: application/grpc+proto
date: Wed, 14 May 2025 12:08:16 GMT
server: pekko-http/1.1.0
x-ratelimit-limit: 0
x-ratelimit-remaining: 0
x-ratelimit-reset: 0
Sent 1 request and received 0 responses
ERROR:
  Code: Unknown
  Message:
```