### PR TITLE
preannounce trailers in server streaming calls

### DIFF
--- a/runtime/src/main/scala/org/apache/pekko/grpc/internal/GrpcResponseHelpers.scala
+++ b/runtime/src/main/scala/org/apache/pekko/grpc/internal/GrpcResponseHelpers.scala
@@ -97,7 +97,10 @@ object GrpcResponseHelpers {
 
   private def response(entity: Source[ChunkStreamPart, NotUsed])(implicit writer: GrpcProtocolWriter) = {
     HttpResponse(
-      headers = immutable.Seq(headers.`Message-Encoding`(writer.messageEncoding.name)),
+      headers = immutable.Seq(
+        headers.`Message-Encoding`(writer.messageEncoding.name),
+        headers.`Trailer`(headers.`Status`.name)
+      ),
       entity = HttpEntity.Chunked(writer.contentType, entity))
   }
 

--- a/runtime/src/main/scala/org/apache/pekko/grpc/scaladsl/headers/headers.scala
+++ b/runtime/src/main/scala/org/apache/pekko/grpc/scaladsl/headers/headers.scala
@@ -111,3 +111,27 @@ object `Status-Message` extends ModeledCustomHeaderCompanion[`Status-Message`] {
   def findIn(headers: immutable.Seq[HttpHeader]): Option[String] =
     headers.collectFirst { case h if h.is(name) => h.value() }
 }
+
+final class `Trailer` private (values: Seq[String]) extends ModeledCustomHeader[`Trailer`] {
+
+  override def companion: ModeledCustomHeaderCompanion[`Trailer`] = `Trailer`
+
+  override def value(): String = values.mkString(", ")
+
+  override def renderInRequests(): Boolean = true
+
+  override def renderInResponses(): Boolean = true
+}
+
+object `Trailer` extends ModeledCustomHeaderCompanion[`Trailer`] {
+  def apply(values: Seq[String]): `Trailer` = new `Trailer`(values.map(_.trim))
+
+  override val name = "Trailer"
+
+  override val lowercaseName: String = super.lowercaseName
+
+  override def parse(value: String): Try[`Trailer`] = Try(`Trailer`(value.split(',')))
+
+  def findIn(headers: immutable.Seq[HttpHeader]): Option[Seq[String]] =
+    headers.collectFirst { case header if header.is(name) => header.value().split(',').map(_.trim).toSeq }
+}


### PR DESCRIPTION
According to [RFC 7230](https://www.rfc-editor.org/rfc/rfc7230) in section 4.4 regarding trailers it says:

> [4.4](https://www.rfc-editor.org/rfc/rfc7230#section-4.4).  Trailer
> When a message includes a message body encoded with the chunked transfer coding and the sender desires to send metadata in the form of trailer fields at the end of the message, the sender SHOULD generate a Trailer header field before the message body to indicate which fields will be present in the trailers. This allows the recipient to prepare for receipt of that metadata before it starts processing the body, which is useful if the message is being streamed and the recipient wishes to confirm an integrity check on the fly.
> Trailer = 1#field-name

When this pre-announcement some reverse proxy applications like tyk misbehave. So even if this is a **_SHOULD_** and not a **_MUST_**, I would appreciate if we could do this.