### PR TITLE
add trailer attribute to trailer only optimized response

### DIFF
--- a/interop-tests/src/test/scala/org/apache/pekko/grpc/scaladsl/GrpcExceptionDefaultHandleSpec.scala
+++ b/interop-tests/src/test/scala/org/apache/pekko/grpc/scaladsl/GrpcExceptionDefaultHandleSpec.scala
@@ -147,7 +147,11 @@ class GrpcExceptionDefaultHandleSpec
         case strict: Strict =>
           strict.contentType.mediaType.toString shouldBe "application/grpc+proto"
           strict.data.isEmpty shouldBe true
-          reply.attribute(AttributeKeys.trailer) shouldBe None
+
+          val trailerAttribute = reply.attribute(AttributeKeys.trailer)
+          trailerAttribute.isDefined shouldBe true
+          val headers = reply.headers.map(header => (header.name(), header.value()))
+          headers should contain allElementsOf trailerAttribute.get.headers
 
           reply.headers
 

--- a/runtime/src/main/scala/org/apache/pekko/grpc/internal/GrpcResponseHelpers.scala
+++ b/runtime/src/main/scala/org/apache/pekko/grpc/internal/GrpcResponseHelpers.scala
@@ -106,11 +106,11 @@ object GrpcResponseHelpers {
   }
 
   def status(trailer: Trailers)(implicit writer: GrpcProtocolWriter): HttpResponse = {
+    val trailerHeaders = GrpcEntityHelpers.trailers(trailer.status, trailer.metadata)
     HttpResponse(
       headers =
-        headers.`Message-Encoding`(writer.messageEncoding.name) ::
-        GrpcEntityHelpers.trailers(trailer.status, trailer.metadata),
+        headers.`Message-Encoding`(writer.messageEncoding.name) :: trailerHeaders,
       entity = HttpEntity.empty(writer.contentType)
-    ).withAttributes(Map(AttributeKeys.trailer -> trailer))
+    ).withAttributes(Map(AttributeKeys.trailer -> Trailer(trailerHeaders)))
   }
 }


### PR DESCRIPTION
Trailer attribute is set by `GrpcProtocolWriter` in the success path but in the failure path it is missing