### PR TITLE
remove function wrapping and deprecate unused function wrapping functions

### DIFF
--- a/runtime/src/main/scala/org/apache/pekko/grpc/javadsl/GrpcMarshalling.scala
+++ b/runtime/src/main/scala/org/apache/pekko/grpc/javadsl/GrpcMarshalling.scala
@@ -65,11 +65,11 @@ object GrpcMarshalling {
       data
         .mapMaterializedValue(_ => NotUsed)
         .via(reader.dataFrameDecoder)
-        .map(japiFunction(u.deserialize))
+        .map(u.deserialize)
         // In gRPC we signal failure by returning an error code, so we
         // don't want the cancellation bubbled out
         .via(new CancellationBarrierGraphStage)
-        .mapMaterializedValue(japiFunction(_ => NotUsed)))
+        .mapMaterializedValue(_ => NotUsed))
   }
   def unmarshalStream[T](
       entity: HttpEntity,

--- a/runtime/src/main/scala/org/apache/pekko/grpc/javadsl/package.scala
+++ b/runtime/src/main/scala/org/apache/pekko/grpc/javadsl/package.scala
@@ -13,6 +13,8 @@
 
 package org.apache.pekko.grpc
 
+import scala.annotation.nowarn
+
 import org.apache.pekko
 
 package object javadsl {
@@ -21,6 +23,7 @@ package object javadsl {
    * Helper for creating org.apache.pekko.japi.function.Function instances from Scala
    * functions as Scala 2.11 does not know about SAMs.
    */
+  @deprecated("no longer needed since support for Scala 2.11 has been dropped", "1.2.0")
   def japiFunction[A, B](f: A => B): pekko.japi.function.Function[A, B] =
     new pekko.japi.function.Function[A, B]() {
       override def apply(a: A): B = f(a)
@@ -30,6 +33,7 @@ package object javadsl {
    * Helper for creating java.util.function.Function instances from Scala
    * functions as Scala 2.11 does not know about SAMs.
    */
+  @deprecated("no longer needed since support for Scala 2.11 has been dropped", "1.2.0")
   def javaFunction[A, B](f: A => B): java.util.function.Function[A, B] =
     new java.util.function.Function[A, B]() {
       override def apply(a: A): B = f(a)
@@ -39,14 +43,16 @@ package object javadsl {
    * Helper for creating Scala partial functions from [[pekko.japi.Function]]
    * instances as Scala 2.11 does not know about SAMs.
    */
+  @deprecated("no longer needed since support for Scala 2.11 has been dropped", "1.2.0")
   def scalaPartialFunction[A, B](f: pekko.japi.Function[A, B]): PartialFunction[A, B] = {
     case a => f(a)
   }
 
   /**
    * Helper for creating Scala anonymous partial functions from [[pekko.japi.Function]]
-   * instances as Scala 2.11 does not know about SAMs.
+   * instances.
    */
+  @nowarn("msg=deprecated")
   def scalaAnonymousPartialFunction[A, B, C](
       f: pekko.japi.Function[A, pekko.japi.Function[B, C]]): A => PartialFunction[B, C] =
     a => scalaPartialFunction(f(a))


### PR DESCRIPTION
* some of the wrapping may only have been needed in Scala 2.11
* tidy up related to #483 but this change is safe for a 1.3.0 release