### PR TITLE
chore: Drop unused deprecated pekko.japi.Function

### DIFF
--- a/codegen/src/main/twirl/templates/JavaServer/Handler.scala.txt
+++ b/codegen/src/main/twirl/templates/JavaServer/Handler.scala.txt
@@ -75,7 +75,7 @@ public class @{serviceName}HandlerFactory {
      * Use {@@link org.apache.pekko.grpc.javadsl.ServiceHandler#concatOrNotFound} with {@@link @{service.name}HandlerFactory#partial} when combining
      * several services.
      */
-    public static Function<org.apache.pekko.http.javadsl.model.HttpRequest, CompletionStage<org.apache.pekko.http.javadsl.model.HttpResponse>> create(@serviceName implementation, org.apache.pekko.japi.Function<ActorSystem, org.apache.pekko.japi.Function<Throwable, Trailers>> eHandler, ClassicActorSystemProvider system) {
+    public static Function<org.apache.pekko.http.javadsl.model.HttpRequest, CompletionStage<org.apache.pekko.http.javadsl.model.HttpResponse>> create(@serviceName implementation, org.apache.pekko.japi.function.Function<ActorSystem, org.apache.pekko.japi.function.Function<Throwable, Trailers>> eHandler, ClassicActorSystemProvider system) {
       return create(implementation, @{service.name}.name, eHandler, system);
     }
 
@@ -101,7 +101,7 @@ public class @{serviceName}HandlerFactory {
      *
      * Registering a gRPC service under a custom prefix is not widely supported and strongly discouraged by the specification.
      */
-    public static Function<org.apache.pekko.http.javadsl.model.HttpRequest, CompletionStage<org.apache.pekko.http.javadsl.model.HttpResponse>> create(@serviceName implementation, String prefix, org.apache.pekko.japi.Function<ActorSystem, org.apache.pekko.japi.Function<Throwable, Trailers>> eHandler, ClassicActorSystemProvider system) {
+    public static Function<org.apache.pekko.http.javadsl.model.HttpRequest, CompletionStage<org.apache.pekko.http.javadsl.model.HttpResponse>> create(@serviceName implementation, String prefix, org.apache.pekko.japi.function.Function<ActorSystem, org.apache.pekko.japi.function.Function<Throwable, Trailers>> eHandler, ClassicActorSystemProvider system) {
       return partial(implementation, prefix, SystemMaterializer.get(system).materializer(), eHandler, system);
     }
 
@@ -142,7 +142,7 @@ public class @{serviceName}HandlerFactory {
      *
      * Use {@@link org.apache.pekko.grpc.javadsl.ServiceHandler#concatOrNotFound} when combining several services.
      */
-    public static Function<org.apache.pekko.http.javadsl.model.HttpRequest, CompletionStage<org.apache.pekko.http.javadsl.model.HttpResponse>> partial(@serviceName implementation, String prefix, Materializer mat, org.apache.pekko.japi.Function<ActorSystem, org.apache.pekko.japi.Function<Throwable, Trailers>> eHandler, ClassicActorSystemProvider system) {
+    public static Function<org.apache.pekko.http.javadsl.model.HttpRequest, CompletionStage<org.apache.pekko.http.javadsl.model.HttpResponse>> partial(@serviceName implementation, String prefix, Materializer mat, org.apache.pekko.japi.function.Function<ActorSystem, org.apache.pekko.japi.function.Function<Throwable, Trailers>> eHandler, ClassicActorSystemProvider system) {
       TelemetrySpi spi = TelemetryExtension.get(system).spi();
       return (req -> {
         Iterator<String> segments = req.getUri().pathSegments().iterator();
@@ -162,7 +162,7 @@ public class @{serviceName}HandlerFactory {
       return @{service.name}.name;
     }
 
-    private static CompletionStage<org.apache.pekko.http.javadsl.model.HttpResponse> handle(org.apache.pekko.http.javadsl.model.HttpRequest request, String method, @serviceName implementation, Materializer mat, org.apache.pekko.japi.Function<ActorSystem, org.apache.pekko.japi.Function<Throwable, Trailers>> eHandler, ClassicActorSystemProvider system) {
+    private static CompletionStage<org.apache.pekko.http.javadsl.model.HttpResponse> handle(org.apache.pekko.http.javadsl.model.HttpRequest request, String method, @serviceName implementation, Materializer mat, org.apache.pekko.japi.function.Function<ActorSystem, org.apache.pekko.japi.function.Function<Throwable, Trailers>> eHandler, ClassicActorSystemProvider system) {
       return GrpcMarshalling.negotiated(request, (reader, writer) -> {
         final CompletionStage<org.apache.pekko.http.javadsl.model.HttpResponse> response;
         @{if(powerApis) { "Metadata metadata = MetadataBuilder.fromHeaders(request.getHeaders());" } else { "" }}

--- a/plugin-tester-java/src/main/java/example/myapp/helloworld/LoggingErrorHandlingGreeterServer.java
+++ b/plugin-tester-java/src/main/java/example/myapp/helloworld/LoggingErrorHandlingGreeterServer.java
@@ -34,7 +34,7 @@ import org.apache.pekko.http.javadsl.model.HttpRequest;
 import org.apache.pekko.http.javadsl.model.HttpResponse;
 import org.apache.pekko.http.javadsl.server.RequestContext;
 import org.apache.pekko.http.javadsl.server.Route;
-import org.apache.pekko.japi.Function;
+import org.apache.pekko.japi.function.Function;
 import org.apache.pekko.stream.Materializer;
 import org.apache.pekko.stream.SystemMaterializer;
 

--- a/runtime/src/main/scala/org/apache/pekko/grpc/javadsl/GrpcExceptionHandler.scala
+++ b/runtime/src/main/scala/org/apache/pekko/grpc/javadsl/GrpcExceptionHandler.scala
@@ -23,7 +23,7 @@ import pekko.grpc.{ GrpcServiceException, Trailers }
 import pekko.grpc.GrpcProtocol.GrpcProtocolWriter
 import pekko.grpc.internal.{ GrpcMetadataImpl, GrpcResponseHelpers, MissingParameterException }
 import pekko.http.javadsl.model.HttpResponse
-import pekko.japi.{ Function => jFunction }
+import pekko.japi.function.{ Function => jFunction }
 import io.grpc.{ Status, StatusRuntimeException }
 
 import org.apache.pekko.http.scaladsl.model.http2.PeerClosedStreamException

--- a/runtime/src/main/scala/org/apache/pekko/grpc/javadsl/GrpcMarshalling.scala
+++ b/runtime/src/main/scala/org/apache/pekko/grpc/javadsl/GrpcMarshalling.scala
@@ -23,7 +23,7 @@ import pekko.grpc._
 import pekko.grpc.internal._
 import pekko.grpc.GrpcProtocol.{ GrpcProtocolReader, GrpcProtocolWriter }
 import pekko.http.javadsl.model.{ HttpEntity, HttpRequest, HttpResponse }
-import pekko.japi.{ Function => JFunction }
+import pekko.japi.function.{ Function => JFunction }
 import pekko.stream.Materializer
 import pekko.stream.javadsl.Source
 import pekko.util.ByteString

--- a/runtime/src/main/scala/org/apache/pekko/grpc/javadsl/package.scala
+++ b/runtime/src/main/scala/org/apache/pekko/grpc/javadsl/package.scala
@@ -40,20 +40,20 @@ package object javadsl {
     }
 
   /**
-   * Helper for creating Scala partial functions from [[pekko.japi.Function]]
+   * Helper for creating Scala partial functions from [[pekko.japi.function.Function]]
    * instances as Scala 2.11 does not know about SAMs.
    */
   @deprecated("no longer needed since support for Scala 2.11 has been dropped", "1.2.0")
-  def scalaPartialFunction[A, B](f: pekko.japi.Function[A, B]): PartialFunction[A, B] = {
+  def scalaPartialFunction[A, B](f: pekko.japi.function.Function[A, B]): PartialFunction[A, B] = {
     case a => f(a)
   }
 
   /**
-   * Helper for creating Scala anonymous partial functions from [[pekko.japi.Function]]
+   * Helper for creating Scala anonymous partial functions from [[pekko.japi.function.Function]]
    * instances.
    */
   @nowarn("msg=deprecated")
   def scalaAnonymousPartialFunction[A, B, C](
-      f: pekko.japi.Function[A, pekko.japi.Function[B, C]]): A => PartialFunction[B, C] =
+      f: pekko.japi.function.Function[A, pekko.japi.function.Function[B, C]]): A => PartialFunction[B, C] =
     a => scalaPartialFunction(f(a))
 }


### PR DESCRIPTION
Motivation:
pekko.japi.Function will be removed in Pekko 2.0.0