### PR TITLE
use 1.2.x snapshots in nightly test workflow

### DIFF
--- a/.github/workflows/nightly-snapshot-dependency-test.yml
+++ b/.github/workflows/nightly-snapshot-dependency-test.yml
@@ -37,4 +37,4 @@ jobs:
       - name: Test
         run: |-
           cp .jvmopts-ci .jvmopts
-          sbt -Dpekko.build.pekko.version=main -Dpekko.build.pekko.http.version=main test
+          sbt -Dpekko.build.pekko.version=1.2.x -Dpekko.build.pekko.http.version=main test


### PR DESCRIPTION
* Pekko 2 is matching 'main' and that has breaking build changes
* Safer to test with latest 1.2.x snapshots
* https://github.com/apache/pekko-grpc/actions/workflows/nightly-snapshot-dependency-test.yml