### PR TITLE
protect 1.2.x branch

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -68,7 +68,19 @@ github:
       required_pull_request_reviews:
         dismiss_stale_reviews: false
         require_code_owner_reviews: false
-        required_approving_review_count: 1    
+        required_approving_review_count: 1
+    1.2.x:
+      required_status_checks:
+        # strict means "Require branches to be up to date before merging".
+        strict: false
+        # contexts are the names of checks that must pass
+        contexts:
+          - Code is formatted
+          - Check headers
+      required_pull_request_reviews:
+        dismiss_stale_reviews: false
+        require_code_owner_reviews: false
+        required_approving_review_count: 1
 
 notifications:
   commits:              commits@pekko.apache.org


### PR DESCRIPTION
* we have changes set for a 1.2.0 release but it doesn't feel urgent
* we can make progress getting 2.0.0 oriented changes in to main branch if we have a dedicated 1.2.x branch