### PR TITLE
use scala converters

### DIFF
--- a/runtime/src/main/scala/org/apache/pekko/grpc/GrpcChannel.scala
+++ b/runtime/src/main/scala/org/apache/pekko/grpc/GrpcChannel.scala
@@ -16,6 +16,7 @@ package org.apache.pekko.grpc
 import java.util.concurrent.CompletionStage
 
 import scala.concurrent.Future
+import scala.jdk.FutureConverters._
 
 import org.apache.pekko
 import pekko.Done
@@ -23,7 +24,6 @@ import pekko.actor.ClassicActorSystemProvider
 import pekko.annotation.InternalStableApi
 import pekko.grpc.internal.{ ChannelUtils, InternalChannel }
 import pekko.grpc.scaladsl.Grpc
-import pekko.util.FutureConverters._
 
 final class GrpcChannel private (
     @InternalStableApi val settings: GrpcClientSettings,

--- a/runtime/src/main/scala/org/apache/pekko/grpc/GrpcClientSettings.scala
+++ b/runtime/src/main/scala/org/apache/pekko/grpc/GrpcClientSettings.scala
@@ -20,7 +20,6 @@ import pekko.discovery.{ Discovery, ServiceDiscovery }
 import pekko.discovery.ServiceDiscovery.{ Resolved, ResolvedTarget }
 import pekko.grpc.internal.HardcodedServiceDiscovery
 import pekko.util.Helpers
-import pekko.util.JavaDurationConverters._
 import com.typesafe.config.{ Config, ConfigValueFactory }
 import io.grpc.CallCredentials
 import io.grpc.netty.shaded.io.grpc.netty.NettyChannelBuilder
@@ -29,6 +28,7 @@ import javax.net.ssl.{ SSLContext, TrustManager }
 
 import scala.collection.immutable
 import scala.concurrent.duration.{ Duration, _ }
+import scala.jdk.DurationConverters._
 
 object GrpcClientSettings {
 
@@ -82,7 +82,7 @@ object GrpcClientSettings {
       implicit actorSystem: ClassicActorSystemProvider): GrpcClientSettings = {
     val clientConfiguration: Config =
       actorSystem.classicSystem.settings.config.getConfig("pekko.grpc.client").getConfig("\"*\"")
-    val resolveTimeout = clientConfiguration.getDuration("service-discovery.resolve-timeout").asScala
+    val resolveTimeout = clientConfiguration.getDuration("service-discovery.resolve-timeout").toScala
     val discovery = Discovery.get(actorSystem).discovery
     withConfigDefaults(serviceName, discovery, -1, resolveTimeout, clientConfiguration)
   }
@@ -99,7 +99,7 @@ object GrpcClientSettings {
       implicit actorSystem: ClassicActorSystemProvider): GrpcClientSettings = {
     val clientConfiguration: Config =
       actorSystem.classicSystem.settings.config.getConfig("pekko.grpc.client").getConfig("\"*\"")
-    val resolveTimeout = clientConfiguration.getDuration("service-discovery.resolve-timeout").asScala
+    val resolveTimeout = clientConfiguration.getDuration("service-discovery.resolve-timeout").toScala
     withConfigDefaults(serviceName, discovery, -1, resolveTimeout, clientConfiguration)
   }
 

--- a/runtime/src/main/scala/org/apache/pekko/grpc/GrpcClientSettings.scala
+++ b/runtime/src/main/scala/org/apache/pekko/grpc/GrpcClientSettings.scala
@@ -110,7 +110,7 @@ object GrpcClientSettings {
     val serviceDiscoveryMechanism = clientConfiguration.getString("service-discovery.mechanism")
     var serviceName = clientConfiguration.getString("service-discovery.service-name")
     val port = clientConfiguration.getInt("port")
-    val resolveTimeout = clientConfiguration.getDuration("service-discovery.resolve-timeout").asScala
+    val resolveTimeout = clientConfiguration.getDuration("service-discovery.resolve-timeout").toScala
     val sd = serviceDiscoveryMechanism match {
       case "static" | "grpc-dns" =>
         val host = clientConfiguration.getString("host")

--- a/runtime/src/main/scala/org/apache/pekko/grpc/internal/MetadataImpl.scala
+++ b/runtime/src/main/scala/org/apache/pekko/grpc/internal/MetadataImpl.scala
@@ -15,16 +15,17 @@ package org.apache.pekko.grpc.internal
 
 import java.util.{ List => jList, Locale, Map => jMap, Optional }
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
+import scala.jdk.FutureConverters._
 import scala.collection.immutable
+
 import org.apache.pekko
 import pekko.annotation.InternalApi
 import pekko.http.scaladsl.model.HttpHeader
 import pekko.japi.Pair
 import pekko.util.ByteString
-import pekko.grpc.scaladsl.{ BytesEntry, Metadata, MetadataEntry, StringEntry }
 import pekko.grpc.javadsl
-import pekko.util.OptionConverters._
+import pekko.grpc.scaladsl.{ BytesEntry, Metadata, MetadataEntry, StringEntry }
 
 @InternalApi private[pekko] object MetadataImpl {
   val BINARY_SUFFIX: String = io.grpc.Metadata.BINARY_HEADER_SUFFIX

--- a/runtime/src/main/scala/org/apache/pekko/grpc/internal/MetadataImpl.scala
+++ b/runtime/src/main/scala/org/apache/pekko/grpc/internal/MetadataImpl.scala
@@ -16,7 +16,7 @@ package org.apache.pekko.grpc.internal
 import java.util.{ List => jList, Locale, Map => jMap, Optional }
 
 import scala.jdk.CollectionConverters._
-import scala.jdk.FutureConverters._
+import scala.jdk.OptionConverters._
 import scala.collection.immutable
 
 import org.apache.pekko

--- a/runtime/src/main/scala/org/apache/pekko/grpc/internal/PekkoHttpClientUtils.scala
+++ b/runtime/src/main/scala/org/apache/pekko/grpc/internal/PekkoHttpClientUtils.scala
@@ -16,7 +16,7 @@ package org.apache.pekko.grpc.internal
 import java.net.InetSocketAddress
 import java.security.SecureRandom
 import java.util.concurrent.CompletionStage
-import scala.concurrent.duration._
+
 import org.apache.pekko
 import pekko.{ Done, NotUsed }
 import pekko.actor.ClassicActorSystemProvider
@@ -32,14 +32,14 @@ import pekko.http.scaladsl.settings.ClientConnectionSettings
 import pekko.stream.{ Materializer, OverflowStrategy }
 import pekko.stream.scaladsl.{ Keep, Sink, Source }
 import pekko.util.ByteString
-import pekko.util.FutureConverters._
 import io.grpc.{ CallOptions, MethodDescriptor, Status, StatusRuntimeException }
 
 import javax.net.ssl.{ KeyManager, SSLContext, TrustManager }
 import scala.collection.immutable
 import scala.concurrent.{ ExecutionContext, Future, Promise }
+import scala.concurrent.duration._
+import scala.jdk.FutureConverters._
 import scala.util.{ Failure, Success }
-import pekko.http.scaladsl.model.StatusCodes
 
 /**
  * INTERNAL API

--- a/runtime/src/main/scala/org/apache/pekko/grpc/internal/PekkoNettyGrpcClientGraphStage.scala
+++ b/runtime/src/main/scala/org/apache/pekko/grpc/internal/PekkoNettyGrpcClientGraphStage.scala
@@ -15,7 +15,6 @@ package org.apache.pekko.grpc.internal
 
 import org.apache.pekko
 import pekko.annotation.InternalApi
-import pekko.dispatch.ExecutionContexts
 import pekko.grpc.{ javadsl, scaladsl, GrpcResponseMetadata }
 import pekko.stream
 import pekko.stream.{ Attributes => _, _ }
@@ -23,7 +22,7 @@ import pekko.stream.stage._
 import io.grpc._
 
 import java.util.concurrent.CompletionStage
-import scala.concurrent.{ Future, Promise }
+import scala.concurrent.{ ExecutionContext, Future, Promise }
 import scala.jdk.FutureConverters._
 
 @InternalApi
@@ -101,9 +100,9 @@ private final class PekkoNettyGrpcClientGraphStage[I, O](
             def getHeaders(): javadsl.Metadata = jMetadata
 
             private lazy val sTrailers =
-              trailerPromise.future.map(MetadataImpl.scalaMetadataFromGoogleGrpcMetadata)(ExecutionContexts.parasitic)
+              trailerPromise.future.map(MetadataImpl.scalaMetadataFromGoogleGrpcMetadata)(ExecutionContext.parasitic)
             private lazy val jTrailers = trailerPromise.future
-              .map(MetadataImpl.javaMetadataFromGoogleGrpcMetadata)(ExecutionContexts.parasitic)
+              .map(MetadataImpl.javaMetadataFromGoogleGrpcMetadata)(ExecutionContext.parasitic)
               .asJava
             def trailers: Future[scaladsl.Metadata] = sTrailers
             def getTrailers(): CompletionStage[javadsl.Metadata] = jTrailers

--- a/runtime/src/main/scala/org/apache/pekko/grpc/internal/PekkoNettyGrpcClientGraphStage.scala
+++ b/runtime/src/main/scala/org/apache/pekko/grpc/internal/PekkoNettyGrpcClientGraphStage.scala
@@ -20,11 +20,11 @@ import pekko.grpc.{ javadsl, scaladsl, GrpcResponseMetadata }
 import pekko.stream
 import pekko.stream.{ Attributes => _, _ }
 import pekko.stream.stage._
-import pekko.util.FutureConverters._
 import io.grpc._
 
 import java.util.concurrent.CompletionStage
 import scala.concurrent.{ Future, Promise }
+import scala.jdk.FutureConverters._
 
 @InternalApi
 private object PekkoNettyGrpcClientGraphStage {

--- a/runtime/src/main/scala/org/apache/pekko/grpc/internal/RequestBuilderImpl.scala
+++ b/runtime/src/main/scala/org/apache/pekko/grpc/internal/RequestBuilderImpl.scala
@@ -18,7 +18,6 @@ import java.util.concurrent.CompletionStage
 import org.apache.pekko
 import pekko.NotUsed
 import pekko.annotation.{ InternalApi, InternalStableApi }
-import pekko.dispatch.ExecutionContexts
 import pekko.grpc.{ GrpcClientSettings, GrpcResponseMetadata, GrpcSingleResponse }
 import pekko.stream.Materializer
 import pekko.stream.javadsl.{ Source => JavaSource }
@@ -119,7 +118,7 @@ final class ScalaClientStreamingRequestBuilder[I, O](
     NettyClientUtils.callOptionsWithDeadline(defaultOptions, settings)
 
   override def invoke(request: Source[I, NotUsed]): Future[O] =
-    invokeWithMetadata(request).map(_.value)(ExecutionContexts.parasitic)
+    invokeWithMetadata(request).map(_.value)(ExecutionContext.parasitic)
 
   override def invokeWithMetadata(source: Source[I, NotUsed]): Future[GrpcSingleResponse[O]] = {
     // a bit much overhead here because we are using the flow to represent a single response
@@ -144,7 +143,7 @@ final class ScalaClientStreamingRequestBuilder[I, O](
             def trailers = metadata.trailers
             def getTrailers() = metadata.getTrailers()
           }
-      }(ExecutionContexts.parasitic)
+      }(ExecutionContext.parasitic)
   }
 
   override def withHeaders(headers: MetadataImpl): ScalaClientStreamingRequestBuilder[I, O] =

--- a/runtime/src/main/scala/org/apache/pekko/grpc/internal/RequestBuilderImpl.scala
+++ b/runtime/src/main/scala/org/apache/pekko/grpc/internal/RequestBuilderImpl.scala
@@ -19,16 +19,15 @@ import org.apache.pekko
 import pekko.NotUsed
 import pekko.annotation.{ InternalApi, InternalStableApi }
 import pekko.dispatch.ExecutionContexts
-import pekko.grpc.{ GrpcResponseMetadata, GrpcSingleResponse }
+import pekko.grpc.{ GrpcClientSettings, GrpcResponseMetadata, GrpcSingleResponse }
 import pekko.stream.Materializer
 import pekko.stream.javadsl.{ Source => JavaSource }
 import pekko.stream.scaladsl.{ Keep, Sink, Source }
 import pekko.util.ByteString
-import pekko.util.FutureConverters._
 import io.grpc._
 
 import scala.concurrent.{ ExecutionContext, Future }
-import pekko.grpc.GrpcClientSettings
+import scala.jdk.FutureConverters._
 
 /**
  * INTERNAL API

--- a/runtime/src/main/scala/org/apache/pekko/grpc/internal/SingleParameterSink.scala
+++ b/runtime/src/main/scala/org/apache/pekko/grpc/internal/SingleParameterSink.scala
@@ -77,7 +77,7 @@ object SingleParameterSink {
     Sink.fromGraph(new SingleParameterStage[T]).withAttributes(Attributes.name("singleParameterSink"))
 
   def create[T](): javadsl.Sink[T, CompletionStage[T]] = {
-    import pekko.util.FutureConverters._
+    import scala.jdk.FutureConverters._
     new javadsl.Sink(SingleParameterSink().mapMaterializedValue(_.asJava))
   }
 }

--- a/runtime/src/main/scala/org/apache/pekko/grpc/internal/UnaryCallAdapter.scala
+++ b/runtime/src/main/scala/org/apache/pekko/grpc/internal/UnaryCallAdapter.scala
@@ -19,11 +19,11 @@ import org.apache.pekko
 import pekko.annotation.InternalApi
 import pekko.dispatch.ExecutionContexts
 import pekko.grpc.GrpcSingleResponse
-import pekko.util.FutureConverters._
 import pekko.util.OptionVal
 import io.grpc._
 
 import scala.concurrent.{ Future, Promise }
+import scala.jdk.FutureConverters._
 
 /**
  * gRPC Netty based client listener transforming callbacks into a future response

--- a/runtime/src/main/scala/org/apache/pekko/grpc/internal/UnaryCallAdapter.scala
+++ b/runtime/src/main/scala/org/apache/pekko/grpc/internal/UnaryCallAdapter.scala
@@ -17,12 +17,11 @@ import java.util.concurrent.CompletionStage
 
 import org.apache.pekko
 import pekko.annotation.InternalApi
-import pekko.dispatch.ExecutionContexts
 import pekko.grpc.GrpcSingleResponse
 import pekko.util.OptionVal
 import io.grpc._
 
-import scala.concurrent.{ Future, Promise }
+import scala.concurrent.{ ExecutionContext, Future, Promise }
 import scala.jdk.FutureConverters._
 
 /**
@@ -90,9 +89,9 @@ private[pekko] final class UnaryCallWithMetadataAdapter[Res] extends ClientCall.
       override def getHeaders() = jMetadata
 
       private lazy val sTrailer =
-        trailerPromise.future.map(MetadataImpl.scalaMetadataFromGoogleGrpcMetadata)(ExecutionContexts.parasitic)
+        trailerPromise.future.map(MetadataImpl.scalaMetadataFromGoogleGrpcMetadata)(ExecutionContext.parasitic)
       private lazy val jTrailer =
-        trailerPromise.future.map(MetadataImpl.javaMetadataFromGoogleGrpcMetadata)(ExecutionContexts.parasitic).asJava
+        trailerPromise.future.map(MetadataImpl.javaMetadataFromGoogleGrpcMetadata)(ExecutionContext.parasitic).asJava
 
       def trailers = sTrailer
       def getTrailers() = jTrailer

--- a/runtime/src/main/scala/org/apache/pekko/grpc/javadsl/ServerReflection.scala
+++ b/runtime/src/main/scala/org/apache/pekko/grpc/javadsl/ServerReflection.scala
@@ -34,7 +34,7 @@ object ServerReflection {
     import scala.collection.JavaConverters._
     val delegate = ServerReflectionHandler.apply(
       ServerReflectionImpl(objects.asScala.map(_.descriptor).toSeq, objects.asScala.map(_.name).toList))(sys)
-    import pekko.util.FutureConverters._
+    import scala.jdk.FutureConverters._
     implicit val ec = sys.classicSystem.dispatcher
     request =>
       delegate

--- a/runtime/src/main/scala/org/apache/pekko/grpc/javadsl/WebHandler.scala
+++ b/runtime/src/main/scala/org/apache/pekko/grpc/javadsl/WebHandler.scala
@@ -54,7 +54,7 @@ object WebHandler {
 
   // Adapt Marshaller.futureMarshaller(fromResponse) to javadsl
   private implicit val csResponseMarshaller: ToResponseMarshaller[CompletionStage[HttpResponse]] = {
-    import pekko.util.FutureConverters._
+    import scala.jdk.FutureConverters._
     // HACK: Only known way to lift this to the scaladsl.model types required for MarshallingDirectives.handleWith
     Marshaller.asScalaToResponseMarshaller(
       Marshaller

--- a/runtime/src/main/scala/org/apache/pekko/grpc/scaladsl/Grpc.scala
+++ b/runtime/src/main/scala/org/apache/pekko/grpc/scaladsl/Grpc.scala
@@ -15,6 +15,7 @@ package org.apache.pekko.grpc.scaladsl
 
 import java.util.concurrent.ConcurrentHashMap
 import scala.concurrent.{ ExecutionContext, Future }
+import scala.jdk.CollectionConverters._
 
 import org.apache.pekko
 import pekko.Done
@@ -22,7 +23,6 @@ import pekko.actor.{ CoordinatedShutdown, ExtendedActorSystem, Extension, Extens
 import pekko.annotation.InternalApi
 import pekko.event.{ LogSource, Logging }
 import pekko.grpc.GrpcChannel
-import pekko.util.ccompat.JavaConverters._
 
 /** INTERNAL API */
 @InternalApi


### PR DESCRIPTION
* with scala 2.12 no longer supported in runtime modules for pekko 2.0.0, we can now use Scala built-in converters