### PR TITLE
[WIP] try to avoid unnecessary step in map conversion

### DIFF
--- a/runtime/src/main/scala/org/apache/pekko/grpc/internal/MetadataImpl.scala
+++ b/runtime/src/main/scala/org/apache/pekko/grpc/internal/MetadataImpl.scala
@@ -204,7 +204,7 @@ class JavaMetadataImpl(delegate: Metadata) extends javadsl.Metadata {
     delegate.getBinary(key).toJava
 
   override def asMap(): jMap[String, jList[javadsl.MetadataEntry]] =
-    delegate.asMap.view.mapValues(_.map(_.asInstanceOf[javadsl.MetadataEntry]).asJava).toMap.asJava
+    delegate.asMap.view.mapValues(_.asJava.asInstanceOf[jList[javadsl.MetadataEntry]]).toMap.asJava
 
   override def asList(): jList[Pair[String, javadsl.MetadataEntry]] =
     delegate.asList.map(t => Pair[String, javadsl.MetadataEntry](t._1, t._2)).asJava


### PR DESCRIPTION
when converting a Scala to Java conversion of Map with a value type that is Seq (that we want to convert to a Java List), we don't want to run a map function on each value seq to cast the type. We can just cast the Seq so change the type.