### PR TITLE
try to avoid unnecessary map conversions in Java DSL

### DIFF
--- a/runtime/src/main/scala/org/apache/pekko/grpc/javadsl/ServerReflection.scala
+++ b/runtime/src/main/scala/org/apache/pekko/grpc/javadsl/ServerReflection.scala
@@ -35,7 +35,6 @@ object ServerReflection {
     val delegate = ServerReflectionHandler.apply(
       ServerReflectionImpl(objects.asScala.map(_.descriptor).toSeq, objects.asScala.map(_.name).toList))(sys)
     import scala.jdk.FutureConverters._
-    // implicit val ec = sys.classicSystem.dispatcher
     request =>
       delegate
         .apply(request.asInstanceOf[pekko.http.scaladsl.model.HttpRequest])

--- a/runtime/src/main/scala/org/apache/pekko/grpc/javadsl/ServerReflection.scala
+++ b/runtime/src/main/scala/org/apache/pekko/grpc/javadsl/ServerReflection.scala
@@ -35,11 +35,11 @@ object ServerReflection {
     val delegate = ServerReflectionHandler.apply(
       ServerReflectionImpl(objects.asScala.map(_.descriptor).toSeq, objects.asScala.map(_.name).toList))(sys)
     import scala.jdk.FutureConverters._
-    implicit val ec = sys.classicSystem.dispatcher
+    // implicit val ec = sys.classicSystem.dispatcher
     request =>
       delegate
         .apply(request.asInstanceOf[pekko.http.scaladsl.model.HttpRequest])
-        .map(_.asInstanceOf[HttpResponse])
         .asJava
+        .asInstanceOf[CompletionStage[HttpResponse]]
   }
 }


### PR DESCRIPTION
* Similar to #520 
* It is hard to avoid doing various map calls on Scala monadic types when converting to Java DSL
* In many cases, the wrapped element(s) are from a class that implements both the Scala and Java DSL APIs so while the return looks like `JavaMonadicType<javadsl.ElementType>` and we start with `ScalaMonadicType[scaladsl.ElementType]` - we do need to change the MonadicType (eg Scala Future to Java CompletionStage) but we don't run a map function to cast the scaladsl.ElementType to javaadsl.ElementType. We can just run a higher level cast, eg cast from  `JavaMonadicType<scaladsl.ElementType>` to `JavaMonadicType<javadsl.ElementType>`