### PR TITLE
pin pekko dependency

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,4 +1,6 @@
 updates.ignore = [
+  # pekko updates are better handled explicitly
+  { groupId = "org.apache.pekko" }
 ]
 
 updates.pin = [


### PR DESCRIPTION
similar to https://github.com/apache/pekko-projection/pull/318 and for the same reason, the ScalaSteward attempt to update our CI files lead to the job being failed because ASF does not allow this