### PR TITLE
publish sbt plugin in legacy style

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -171,6 +171,7 @@ lazy val sbtPlugin = Project(id = "sbt-plugin", base = file("sbt-plugin"))
   .settings(Dependencies.sbtPlugin)
   .settings(
     name := s"$pekkoPrefix-sbt-plugin",
+    sbtPluginPublishLegacyMavenStyle := true,
     /** And for scripted tests: */
     scriptedLaunchOpts += ("-Dproject.version=" + version.value),
     scriptedLaunchOpts ++= sys.props.collect { case (k @ "sbt.ivy.home", v) => s"-D$k=$v" }.toSeq,


### PR DESCRIPTION
* relates to #540 
* this flag means the plugin gets published in both the legacy and new style
* seems like sbt changed the default for this flag somewhere around the 1.11.0 release. We published pekko-grpc 1.1.1 with sbt 1.10.4 and the legacy style was supported despite us not setting this flag
* I have tested publishing locally to verify that this helps