### PR TITLE
Update sbt-pekko-build to 0.4.7 (#561)

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -25,7 +25,7 @@ addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "1.1.4")
 addSbtPlugin("net.bzzt" % "sbt-reproducible-builds" % "0.32")
 addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.4.7")
 addSbtPlugin("com.github.sbt" % "sbt-dynver" % "5.1.1")
-addSbtPlugin("com.github.pjfanning" % "sbt-pekko-build" % "0.4.5")
+addSbtPlugin("com.github.pjfanning" % "sbt-pekko-build" % "0.4.7")
 addSbtPlugin("com.github.pjfanning" % "sbt-source-dist" % "0.1.13")
 addSbtPlugin("com.github.sbt" % "sbt-license-report" % "1.7.0")
 


### PR DESCRIPTION
cherry pick d9d43158ea7784ce36568028b983ae94136b148f

Useful to allow testing with latest pekko snapshots (the plugin has updates to allow latest branches to be used)