### PR TITLE
test code that causes compile warning and fails strict build

### DIFF
--- a/interop-tests/src/test/scala/org/apache/pekko/grpc/scaladsl/GrpcMarshallingSpec.scala
+++ b/interop-tests/src/test/scala/org/apache/pekko/grpc/scaladsl/GrpcMarshallingSpec.scala
@@ -61,8 +61,7 @@ class GrpcMarshallingSpec extends AnyWordSpec with Matchers {
         headers = immutable.Seq(`Message-Encoding`("gzip")),
         entity = HttpEntity.Chunked(
           GrpcProtocolNative.contentType,
-          TestSource
-            .probe[ChunkStreamPart]
+          TestSource[ChunkStreamPart]()
             .mapMaterializedValue((p: TestPublisher.Probe[ChunkStreamPart]) => {
               sourceProbe.success(p)
               NotUsed


### PR DESCRIPTION
pekko 1.3 deprecated TestSource.probe and when you have strict builds in sbt, a compile warning fails the build

https://github.com/apache/pekko-grpc/actions/runs/20367513616/job/58527042687

main branch has this change and more but I just want to do the minimal change in 1.x branches - just enough to fix the build