### PR TITLE
use `pekko.http.server.enable-http2`

### DIFF
--- a/benchmark-java/src/main/java/org/apache/pekko/grpc/benchmarks/driver/LoadWorker.java
+++ b/benchmark-java/src/main/java/org/apache/pekko/grpc/benchmarks/driver/LoadWorker.java
@@ -128,7 +128,7 @@ public class LoadWorker {
 
 
     // important to enable HTTP/2 in ActorSystem's config
-    Config conf = ConfigFactory.parseString("pekko.http.server.preview.enable-http2 = on")
+    Config conf = ConfigFactory.parseString("pekko.http.server.enable-http2 = on")
         .withFallback(ConfigFactory.defaultApplication());
     ActorSystem system = ActorSystem.create("LoadWorker", conf);
     new LoadWorker(system, driverPort, serverPort).start();

--- a/benchmark-java/src/main/java/org/apache/pekko/grpc/benchmarks/qps/AsyncServer.java
+++ b/benchmark-java/src/main/java/org/apache/pekko/grpc/benchmarks/qps/AsyncServer.java
@@ -67,7 +67,7 @@ public class AsyncServer {
   public void run(InetSocketAddress address, boolean useTls) throws Exception {
     // important to enable HTTP/2 in ActorSystem's config
 
-    Config conf = ConfigFactory.parseString("pekko.http.server.preview.enable-http2 = on")
+    Config conf = ConfigFactory.parseString("pekko.http.server.enable-http2 = on")
         .withFallback(ConfigFactory.defaultApplication());
 
     system = ActorSystem.create("AsyncServer", conf);

--- a/benchmark-java/src/test/java/org/apache/pekko/grpc/benchmarks/driver/LoadWorkerTest.java
+++ b/benchmark-java/src/test/java/org/apache/pekko/grpc/benchmarks/driver/LoadWorkerTest.java
@@ -69,7 +69,7 @@ public class LoadWorkerTest extends JUnitSuite {
   @Before
   public void setup() throws Exception {
     // important to enable HTTP/2 in ActorSystem's config
-    Config conf = ConfigFactory.parseString("pekko.http.server.preview.enable-http2 = on")
+    Config conf = ConfigFactory.parseString("pekko.http.server.enable-http2 = on")
         .withFallback(ConfigFactory.defaultApplication());
     system = ActorSystem.create("LoadWorkerTest", conf);
     mat = SystemMaterializer.get(system).materializer();

--- a/docs/src/main/paradox/server/walkthrough.md
+++ b/docs/src/main/paradox/server/walkthrough.md
@@ -196,7 +196,7 @@ Java
 It's important to enable HTTP/2 in Pekko HTTP in the configuration of the `ActorSystem` by setting
 
 ```
-pekko.http.server.preview.enable-http2 = on
+pekko.http.server.enable-http2 = on
 ```
 
 In the example this was done from the `main` method, but you could also do this from within your `application.conf`.

--- a/docs/src/main/paradox/troubleshooting.md
+++ b/docs/src/main/paradox/troubleshooting.md
@@ -15,5 +15,5 @@ gRPC server with a client that is configured with TLS enabled.
 java.util.concurrent.ExecutionException: io.grpc.StatusRuntimeException: UNAVAILABLE: Failed ALPN negotiation: Unable to find compatible protocol
 ```
 
-This may happen when `pekko.http.server.preview.enable-http2` is not enabled in
+This may happen when `pekko.http.server.enable-http2` is not enabled in
 the configuration.

--- a/interop-tests/src/main/java/org/apache/pekko/grpc/interop/PekkoGrpcServerJava.java
+++ b/interop-tests/src/main/java/org/apache/pekko/grpc/interop/PekkoGrpcServerJava.java
@@ -64,7 +64,7 @@ public class PekkoGrpcServerJava extends GrpcServer<Tuple2<ActorSystem, ServerBi
     ActorSystem sys =
         ActorSystem.create(
             "pekko-grpc-server-java",
-            ConfigFactory.parseString("pekko.http.server.preview.enable-http2 = on"));
+            ConfigFactory.parseString("pekko.http.server.enable-http2 = on"));
     Materializer mat = SystemMaterializer.get(sys).materializer();
 
     Function<HttpRequest, CompletionStage<HttpResponse>> testService =

--- a/plugin-tester-java/src/main/java/example/myapp/CombinedServer.java
+++ b/plugin-tester-java/src/main/java/example/myapp/CombinedServer.java
@@ -44,7 +44,7 @@ import example.myapp.echo.grpc.*;
 class CombinedServer {
   public static void main(String[] args) {
       // important to enable HTTP/2 in ActorSystem's config
-      Config conf = ConfigFactory.parseString("pekko.http.server.preview.enable-http2 = on")
+      Config conf = ConfigFactory.parseString("pekko.http.server.enable-http2 = on")
         .withFallback(ConfigFactory.defaultApplication());
       ActorSystem sys = ActorSystem.create("HelloWorld", conf);
       Materializer mat = SystemMaterializer.get(sys).materializer();

--- a/plugin-tester-java/src/main/java/example/myapp/helloworld/AuthenticatedGreeterServer.java
+++ b/plugin-tester-java/src/main/java/example/myapp/helloworld/AuthenticatedGreeterServer.java
@@ -35,7 +35,7 @@ class AuthenticatedGreeterServer {
   public static void main(String[] args) throws Exception {
     // important to enable HTTP/2 in ActorSystem's config
     Config conf =
-        ConfigFactory.parseString("pekko.http.server.preview.enable-http2 = on")
+        ConfigFactory.parseString("pekko.http.server.enable-http2 = on")
             .withFallback(ConfigFactory.defaultApplication());
 
     // ActorSystem Boot

--- a/plugin-tester-java/src/main/java/example/myapp/helloworld/GreeterServer.java
+++ b/plugin-tester-java/src/main/java/example/myapp/helloworld/GreeterServer.java
@@ -29,7 +29,7 @@ class GreeterServer {
   public static void main(String[] args) throws Exception {
     // important to enable HTTP/2 in ActorSystem's config
     Config conf =
-        ConfigFactory.parseString("pekko.http.server.preview.enable-http2 = on")
+        ConfigFactory.parseString("pekko.http.server.enable-http2 = on")
             .withFallback(ConfigFactory.defaultApplication());
 
     // ActorSystem Boot

--- a/plugin-tester-java/src/main/java/example/myapp/helloworld/LoggingErrorHandlingGreeterServer.java
+++ b/plugin-tester-java/src/main/java/example/myapp/helloworld/LoggingErrorHandlingGreeterServer.java
@@ -42,7 +42,7 @@ public class LoggingErrorHandlingGreeterServer {
   public static void main(String[] args) throws Exception {
     // important to enable HTTP/2 in ActorSystem's config
     Config conf =
-        ConfigFactory.parseString("pekko.http.server.preview.enable-http2 = on")
+        ConfigFactory.parseString("pekko.http.server.enable-http2 = on")
             .withFallback(ConfigFactory.defaultApplication());
 
     // ActorSystem Boot

--- a/plugin-tester-java/src/main/java/example/myapp/helloworld/PowerGreeterServer.java
+++ b/plugin-tester-java/src/main/java/example/myapp/helloworld/PowerGreeterServer.java
@@ -29,7 +29,7 @@ class PowerGreeterServer {
   public static void main(String[] args) throws Exception {
     // important to enable HTTP/2 in ActorSystem's config
     Config conf =
-        ConfigFactory.parseString("pekko.http.server.preview.enable-http2 = on")
+        ConfigFactory.parseString("pekko.http.server.enable-http2 = on")
             .withFallback(ConfigFactory.defaultApplication());
 
     // ActorSystem Boot

--- a/plugin-tester-java/src/test/scala/example/myapp/helloworld/JGreeterServiceSpec.scala
+++ b/plugin-tester-java/src/test/scala/example/myapp/helloworld/JGreeterServiceSpec.scala
@@ -38,7 +38,7 @@ class JGreeterServiceSpec extends Matchers with AnyWordSpecLike with BeforeAndAf
   implicit val serverSystem: ActorSystem = {
     // important to enable HTTP/2 in server ActorSystem's config
     val conf = ConfigFactory
-      .parseString("pekko.http.server.preview.enable-http2 = on")
+      .parseString("pekko.http.server.enable-http2 = on")
       .withFallback(ConfigFactory.defaultApplication())
     val sys = ActorSystem("GreeterServer", conf)
     // make sure servers are bound before using client

--- a/plugin-tester-scala/src/main/scala/example/myapp/CombinedServer.scala
+++ b/plugin-tester-scala/src/main/scala/example/myapp/CombinedServer.scala
@@ -41,7 +41,7 @@ object CombinedServer {
   def main(args: Array[String]): Unit = {
     // important to enable HTTP/2 in ActorSystem's config
     val conf = ConfigFactory
-      .parseString("pekko.http.server.preview.enable-http2 = on")
+      .parseString("pekko.http.server.enable-http2 = on")
       .withFallback(ConfigFactory.defaultApplication())
     implicit val sys: ActorSystem = ActorSystem("HelloWorld", conf)
     implicit val ec: ExecutionContext = sys.dispatcher

--- a/plugin-tester-scala/src/main/scala/example/myapp/helloworld/AuthenticatedGreeterServer.scala
+++ b/plugin-tester-scala/src/main/scala/example/myapp/helloworld/AuthenticatedGreeterServer.scala
@@ -29,7 +29,7 @@ object AuthenticatedGreeterServer {
     // Important: enable HTTP/2 in ActorSystem's config
     // We do it here programmatically, but you can also set it in the application.conf
     val conf = ConfigFactory
-      .parseString("pekko.http.server.preview.enable-http2 = on")
+      .parseString("pekko.http.server.enable-http2 = on")
       .withFallback(ConfigFactory.defaultApplication())
     val system = ActorSystem("HelloWorld", conf)
     new AuthenticatedGreeterServer(system).run()

--- a/plugin-tester-scala/src/main/scala/example/myapp/helloworld/GreeterServer.scala
+++ b/plugin-tester-scala/src/main/scala/example/myapp/helloworld/GreeterServer.scala
@@ -28,7 +28,7 @@ object GreeterServer {
     // Important: enable HTTP/2 in ActorSystem's config
     // We do it here programmatically, but you can also set it in the application.conf
     val conf = ConfigFactory
-      .parseString("pekko.http.server.preview.enable-http2 = on")
+      .parseString("pekko.http.server.enable-http2 = on")
       .withFallback(ConfigFactory.defaultApplication())
     val system = ActorSystem("HelloWorld", conf)
     new GreeterServer(system).run()

--- a/plugin-tester-scala/src/main/scala/example/myapp/helloworld/LoggingErrorHandlingGreeterServer.scala
+++ b/plugin-tester-scala/src/main/scala/example/myapp/helloworld/LoggingErrorHandlingGreeterServer.scala
@@ -34,7 +34,7 @@ import scala.util.control.NonFatal
 object LoggingErrorHandlingGreeterServer {
   def main(args: Array[String]): Unit = {
     val conf = ConfigFactory
-      .parseString("pekko.http.server.preview.enable-http2 = on")
+      .parseString("pekko.http.server.enable-http2 = on")
       .withFallback(ConfigFactory.defaultApplication())
     val system = ActorSystem("Server", conf)
     new LoggingErrorHandlingGreeterServer(system).run()

--- a/plugin-tester-scala/src/test/scala/example/myapp/helloworld/GreeterServiceSpec.scala
+++ b/plugin-tester-scala/src/test/scala/example/myapp/helloworld/GreeterServiceSpec.scala
@@ -38,7 +38,7 @@ class GreeterServiceSpec extends Matchers with AnyWordSpecLike with BeforeAndAft
   implicit val serverSystem: ActorSystem = {
     // important to enable HTTP/2 in server ActorSystem's config
     val conf = ConfigFactory
-      .parseString("pekko.http.server.preview.enable-http2 = on")
+      .parseString("pekko.http.server.enable-http2 = on")
       .withFallback(ConfigFactory.defaultApplication())
     val sys = ActorSystem("GreeterServer", conf)
     // make sure servers are bound before using client

--- a/sbt-plugin/src/sbt-test/gen-java/02-server-reflection/src/main/java/example/myapp/helloworld/Main.java
+++ b/sbt-plugin/src/sbt-test/gen-java/02-server-reflection/src/main/java/example/myapp/helloworld/Main.java
@@ -34,7 +34,7 @@ import example.myapp.helloworld.grpc.*;
 public class Main {
     public static void main(String[] args) throws Exception {
         // important to enable HTTP/2 in ActorSystem's config
-        Config conf = ConfigFactory.parseString("pekko.http.server.preview.enable-http2 = on")
+        Config conf = ConfigFactory.parseString("pekko.http.server.enable-http2 = on")
             .withFallback(ConfigFactory.defaultApplication());
         // ActorSystem Boot
         ActorSystem sys = ActorSystem.create("HelloWorld", conf);

--- a/sbt-plugin/src/sbt-test/gen-scala-server/00-interop/src/main/resources/application.conf
+++ b/sbt-plugin/src/sbt-test/gen-scala-server/00-interop/src/main/resources/application.conf
@@ -1,3 +1,3 @@
 # SPDX-License-Identifier: Apache-2.0
 
-pekko.http.server.preview.enable-http2 = on
+pekko.http.server.enable-http2 = on

--- a/sbt-plugin/src/sbt-test/gen-scala-server/04-server-reflection/src/main/scala/example/myapp/helloworld/Main.scala
+++ b/sbt-plugin/src/sbt-test/gen-scala-server/04-server-reflection/src/main/scala/example/myapp/helloworld/Main.scala
@@ -31,7 +31,7 @@ import example.myapp.helloworld.grpc._
 
 object Main extends App {
   val conf = ConfigFactory
-    .parseString("pekko.http.server.preview.enable-http2 = on")
+    .parseString("pekko.http.server.enable-http2 = on")
     .withFallback(ConfigFactory.defaultApplication())
   implicit val sys: ActorSystem = ActorSystem("HelloWorld", conf)
 

--- a/sbt-plugin/src/sbt-test/scala3/01-basic-client-server/src/main/resources/application.conf
+++ b/sbt-plugin/src/sbt-test/scala3/01-basic-client-server/src/main/resources/application.conf
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-pekko.http.server.preview.enable-http2 = on
+pekko.http.server.enable-http2 = on
 
 pekko.grpc.client."*" {
   backend = "pekko-http"


### PR DESCRIPTION
`pekko.http.server.enable-http2` is now preferred to the old preview config