### PR TITLE
scalapb 1.0.0 alpha support protobuf 4

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -177,7 +177,7 @@ lazy val sbtPlugin = Project(id = "sbt-plugin", base = file("sbt-plugin"))
       val p3 = (runtime / publishLocal).value
       val p4 = (interopTests / publishLocal).value
     },
-    scriptedSbt := "1.12.9",
+    scriptedSbt := "1.12.11",
     scriptedBufferLog := false)
   .settings(
     crossScalaVersions := Dependencies.Versions.CrossScalaForPlugin,
@@ -315,7 +315,12 @@ lazy val pluginTesterScala = Project(id = "plugin-tester-scala", base = file("pl
     PB.protocVersion := Dependencies.Versions.googleProtoc,
     crossScalaVersions := Dependencies.Versions.CrossScalaForLib,
     scalaVersion := Dependencies.Versions.CrossScalaForLib.head,
-    ReflectiveCodeGen.codeGeneratorSettings ++= Seq("flat_package", "server_power_apis"))
+    ReflectiveCodeGen.codeGeneratorSettings ++= Seq("flat_package", "server_power_apis"),
+    // the following is needed to exclude the gRPC generated sources for protobuf-java from the sources,
+    // they cause tests to fail - https://github.com/apache/pekko-grpc/pull/610
+    Compile / sources := (Compile / sources).value.filterNot { f =>
+      f.getPath.replace('\\', '/').contains("/src_managed/main/com/google/protobuf")
+    })
   .pluginTestingSettings
   .enablePlugins(NoPublish)
 

--- a/build.sbt
+++ b/build.sbt
@@ -209,6 +209,11 @@ lazy val interopTests = Project(id = "interop-tests", base = file("interop-tests
     // We need to be able to publish locally in order for sbt interopt tests to work
     // however this sbt project should not be published to an actual repository
     publishLocal / skip := false,
+    // the following is needed to exclude the gRPC generated sources for protobuf-java from the sources,
+    // they cause tests to fail - https://github.com/apache/pekko-grpc/pull/610
+    Compile / sources := (Compile / sources).value.filterNot { f =>
+      f.getPath.replace('\\', '/').contains("/src_managed/main/com/google/protobuf")
+    },
     Compile / doc := (Compile / doc / target).value)
   .settings(inConfig(Test)(Seq(
     reStart / mainClass := (Test / run / mainClass).value, {

--- a/codegen/src/main/scala/org/apache/pekko/grpc/gen/scaladsl/Service.scala
+++ b/codegen/src/main/scala/org/apache/pekko/grpc/gen/scaladsl/Service.scala
@@ -50,7 +50,7 @@ object Service {
 
     Service(
       fileDesc.fileDescriptorObject.fullName + ".javaDescriptor",
-      fileDesc.scalaPackage.fullName,
+      trimRootPackage(fileDesc.scalaPackage.fullName),
       serviceClassName,
       (if (fileDesc.getPackage.isEmpty) "" else fileDesc.getPackage + ".") + serviceDescriptor.getName,
       serviceDescriptor.getMethods.asScala.map(method => Method(method)).toList,
@@ -59,5 +59,11 @@ object Service {
       serviceDescriptor.getOptions,
       serviceDescriptor.comment,
       new ScalaCompatConstants(fileDesc.emitScala3Sources))
+  }
+
+  private def trimRootPackage(packageName: String): String = {
+    val prefix = "_root_."
+    if (packageName.startsWith(prefix)) packageName.substring(prefix.length)
+    else packageName
   }
 }

--- a/gradle-plugin/src/main/groovy/org/apache/pekko/grpc/gradle/PekkoGrpcPluginExtension.groovy
+++ b/gradle-plugin/src/main/groovy/org/apache/pekko/grpc/gradle/PekkoGrpcPluginExtension.groovy
@@ -14,7 +14,7 @@ import org.gradle.api.Project
 
 class PekkoGrpcPluginExtension {
 
-    static final String PROTOC_VERSION = "4.35.0" // checked synced by VersionSyncCheckPlugin
+    static final String PROTOC_VERSION = "4.32.1" // checked synced by VersionSyncCheckPlugin
 
     static final String PROTOC_PLUGIN_SCALA_VERSION = "2.12"
 

--- a/gradle-plugin/src/main/groovy/org/apache/pekko/grpc/gradle/PekkoGrpcPluginExtension.groovy
+++ b/gradle-plugin/src/main/groovy/org/apache/pekko/grpc/gradle/PekkoGrpcPluginExtension.groovy
@@ -14,7 +14,7 @@ import org.gradle.api.Project
 
 class PekkoGrpcPluginExtension {
 
-    static final String PROTOC_VERSION = "3.25.9" // checked synced by VersionSyncCheckPlugin
+    static final String PROTOC_VERSION = "4.35.0" // checked synced by VersionSyncCheckPlugin
 
     static final String PROTOC_PLUGIN_SCALA_VERSION = "2.12"
 

--- a/maven-plugin/src/main/maven/plugin.xml
+++ b/maven-plugin/src/main/maven/plugin.xml
@@ -99,7 +99,7 @@
         <extraGenerators implementation="java.util.List" default-value=""/>
         <protoPaths default-value="${project.basedir}/src/main/proto,${project.basedir}/src/main/protobuf">${pekko-grpc.protoPaths}</protoPaths>
         <outputDirectory default-value="${project.build.directory}/generated-sources">${pekko-grpc.outputDirectory}</outputDirectory>
-	      <protocVersion implementation="java.lang.String" default-value="-v4.35.0">${pekko-grpc.protoc-version}</protocVersion> <!-- checked synced by VersionSyncCheckPlugin -->
+	      <protocVersion implementation="java.lang.String" default-value="-v4.32.1">${pekko-grpc.protoc-version}</protocVersion> <!-- checked synced by VersionSyncCheckPlugin -->
         <includeStdTypes implementation="boolean" default-value="false" />
       </configuration>
     </mojo>
@@ -191,7 +191,7 @@
         <extraGenerators implementation="java.util.List" default-value=""/>
         <protoPaths default-value="src/test/proto,src/test/protobuf">${pekko-grpc.protoPaths}</protoPaths>
         <outputDirectory default-value="target/generated-test-sources">${pekko-grpc.outputDirectory}</outputDirectory>
-        <protocVersion implementation="java.lang.String" default-value="-v4.35.0">${pekko-grpc.protoc-version}</protocVersion> <!-- checked synced by VersionSyncCheckPlugin -->
+        <protocVersion implementation="java.lang.String" default-value="-v4.32.1">${pekko-grpc.protoc-version}</protocVersion> <!-- checked synced by VersionSyncCheckPlugin -->
         <includeStdTypes implementation="boolean" default-value="false" />
       </configuration>
     </mojo>

--- a/maven-plugin/src/main/maven/plugin.xml
+++ b/maven-plugin/src/main/maven/plugin.xml
@@ -99,7 +99,7 @@
         <extraGenerators implementation="java.util.List" default-value=""/>
         <protoPaths default-value="${project.basedir}/src/main/proto,${project.basedir}/src/main/protobuf">${pekko-grpc.protoPaths}</protoPaths>
         <outputDirectory default-value="${project.build.directory}/generated-sources">${pekko-grpc.outputDirectory}</outputDirectory>
-	      <protocVersion implementation="java.lang.String" default-value="-v4.32.1">${pekko-grpc.protoc-version}</protocVersion> <!-- checked synced by VersionSyncCheckPlugin -->
+        <protocVersion implementation="java.lang.String" default-value="-v4.32.1">${pekko-grpc.protoc-version}</protocVersion> <!-- checked synced by VersionSyncCheckPlugin -->
         <includeStdTypes implementation="boolean" default-value="false" />
       </configuration>
     </mojo>

--- a/maven-plugin/src/main/maven/plugin.xml
+++ b/maven-plugin/src/main/maven/plugin.xml
@@ -99,7 +99,7 @@
         <extraGenerators implementation="java.util.List" default-value=""/>
         <protoPaths default-value="${project.basedir}/src/main/proto,${project.basedir}/src/main/protobuf">${pekko-grpc.protoPaths}</protoPaths>
         <outputDirectory default-value="${project.build.directory}/generated-sources">${pekko-grpc.outputDirectory}</outputDirectory>
-	<protocVersion implementation="java.lang.String" default-value="-v3.25.9">${pekko-grpc.protoc-version}</protocVersion> <!-- checked synced by VersionSyncCheckPlugin -->
+	      <protocVersion implementation="java.lang.String" default-value="-v4.35.0">${pekko-grpc.protoc-version}</protocVersion> <!-- checked synced by VersionSyncCheckPlugin -->
         <includeStdTypes implementation="boolean" default-value="false" />
       </configuration>
     </mojo>
@@ -191,7 +191,7 @@
         <extraGenerators implementation="java.util.List" default-value=""/>
         <protoPaths default-value="src/test/proto,src/test/protobuf">${pekko-grpc.protoPaths}</protoPaths>
         <outputDirectory default-value="target/generated-test-sources">${pekko-grpc.outputDirectory}</outputDirectory>
-        <protocVersion implementation="java.lang.String" default-value="-v3.25.9">${pekko-grpc.protoc-version}</protocVersion> <!-- checked synced by VersionSyncCheckPlugin -->
+        <protocVersion implementation="java.lang.String" default-value="-v4.35.0">${pekko-grpc.protoc-version}</protocVersion> <!-- checked synced by VersionSyncCheckPlugin -->
         <includeStdTypes implementation="boolean" default-value="false" />
       </configuration>
     </mojo>

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -37,8 +37,8 @@ object Dependencies {
     // Even referenced explicitly in the sbt-plugin's sbt-tests
     // If changing this, remember to update protoc plugin version to align in
     // maven-plugin/src/main/maven/plugin.xml and org.apache.pekko.grpc.sbt.PekkoGrpcPlugin
-    val googleProtoc = "3.25.9" // checked synced by VersionSyncCheckPlugin
-    val googleProtobufJava = "3.25.9"
+    val googleProtoc = "4.35.0" // checked synced by VersionSyncCheckPlugin
+    val googleProtobufJava = "4.35.0"
 
     val scalaTest = "3.2.20"
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -37,8 +37,8 @@ object Dependencies {
     // Even referenced explicitly in the sbt-plugin's sbt-tests
     // If changing this, remember to update protoc plugin version to align in
     // maven-plugin/src/main/maven/plugin.xml and org.apache.pekko.grpc.sbt.PekkoGrpcPlugin
-    val googleProtoc = "4.35.0" // checked synced by VersionSyncCheckPlugin
-    val googleProtobufJava = "4.35.0"
+    val googleProtoc = "4.32.1" // checked synced by VersionSyncCheckPlugin
+    val googleProtobufJava = "4.32.1"
 
     val scalaTest = "3.2.20"
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -42,4 +42,4 @@ libraryDependencies += "org.eclipse.jgit" % "org.eclipse.jgit" % "5.13.5.2025082
 // scripted testing
 libraryDependencies += "org.scala-sbt" %% "scripted-plugin" % sbtVersion.value
 
-libraryDependencies += "com.thesamet.scalapb" %% "compilerplugin" % "0.11.20"
+libraryDependencies += "com.thesamet.scalapb" %% "compilerplugin" % "1.0.0-alpha.4"

--- a/sbt-plugin/src/sbt-test/gen-scala-server/10-scalapb-validate/build.sbt
+++ b/sbt-plugin/src/sbt-test/gen-scala-server/10-scalapb-validate/build.sbt
@@ -12,10 +12,10 @@ import scalapb.GeneratorOption._
 
 scalaVersion := "2.13.18"
 
-enablePlugins(PekkoGrpcPlugin)
-
 // ScalaPB Validate sbt plugin does not have a release that supports ScalaPB 1.0.0
-evictionErrorLevel := Level.Info
+Global / evictionErrorLevel := Level.Info
+
+enablePlugins(PekkoGrpcPlugin)
 
 libraryDependencies +=
   "com.thesamet.scalapb" %% "scalapb-validate-core" % scalapb.validate.compiler.BuildInfo.version % "protobuf"

--- a/sbt-plugin/src/sbt-test/gen-scala-server/10-scalapb-validate/build.sbt
+++ b/sbt-plugin/src/sbt-test/gen-scala-server/10-scalapb-validate/build.sbt
@@ -14,6 +14,9 @@ scalaVersion := "2.13.18"
 
 enablePlugins(PekkoGrpcPlugin)
 
+// ScalaPB Validate sbt plugin does not have a release that supports ScalaPB 1.0.0
+evictionErrorLevel := Level.Info
+
 libraryDependencies +=
   "com.thesamet.scalapb" %% "scalapb-validate-core" % scalapb.validate.compiler.BuildInfo.version % "protobuf"
 Compile / PB.targets +=

--- a/sbt-plugin/src/sbt-test/gen-scala-server/10-scalapb-validate/project/plugins.sbt
+++ b/sbt-plugin/src/sbt-test/gen-scala-server/10-scalapb-validate/project/plugins.sbt
@@ -9,4 +9,7 @@
 
 addSbtPlugin("org.apache.pekko" % "pekko-grpc-sbt-plugin" % sys.props("project.version"))
 
+// ScalaPB Validate sbt plugin does not have a release that supports ScalaPB 1.0.0
+Global / evictionErrorLevel := Level.Info
+
 libraryDependencies ++= Seq("com.thesamet.scalapb" %% "scalapb-validate-codegen" % "0.3.6")


### PR DESCRIPTION
* one hack was required in the Scala code generator
* had to block the parsing of generated source code in the com.google.protobuf package because the generated classes clashed the equivalents in protobuf-java jar.
* the maven tests needed #709 
* sbt plugin tests pass - except 10-scalapb-validate which hits issues with jar version conflicts
* the scalapb jar is marked as alpha4 but it works and it unblocks us upgrading protobuf/protoc and let's us move onto supporting sbt2
