### PR TITLE
chore: replace per-site @nowarn with scoped -Wconf in codegen

### DIFF
--- a/codegen/src/main/scala/org/apache/pekko/grpc/gen/CodeGenerator.scala
+++ b/codegen/src/main/scala/org/apache/pekko/grpc/gen/CodeGenerator.scala
@@ -13,7 +13,6 @@
 
 package org.apache.pekko.grpc.gen
 
-import scala.annotation.nowarn
 import com.google.protobuf.ExtensionRegistry
 import com.google.protobuf.compiler.PluginProtos.CodeGeneratorRequest
 import com.google.protobuf.compiler.PluginProtos.CodeGeneratorResponse
@@ -33,7 +32,7 @@ trait CodeGenerator {
   /** Takes Scala binary version and returns suggested dependency Seq */
   def suggestedDependencies: ScalaBinaryVersion => Seq[Artifact]
 
-  def registerExtensions(@nowarn("msg=is never used") registry: ExtensionRegistry): Unit = {}
+  def registerExtensions(registry: ExtensionRegistry): Unit = {}
 
   final def run(request: Array[Byte], logger: Logger): Array[Byte] = {
     val registry = ExtensionRegistry.newInstance

--- a/project/Common.scala
+++ b/project/Common.scala
@@ -67,6 +67,9 @@ object Common extends AutoPlugin {
          Seq(
            // Generated code for methods/fields marked 'deprecated'
            "-Wconf:msg=Marked as deprecated in proto file:silent",
+           // Suppress "parameter X is never used" in CodeGenerator's registerExtensions
+           // default trait impl. Uses precise path+msg filter to avoid masking real warnings.
+           "-Wconf:src=.*/grpc/gen/CodeGenerator\\.scala:msg=is never used:silent",
            // ignore imports in templates (FIXME why is that trailing .* needed?)
            "-Wconf:src=.*.txt.*:silent",
            "-Wconf:cat=unused-nowarn:silent")


### PR DESCRIPTION
## Motivation

In the Scala 2.12 codegen module, `@nowarn("cat=unused-params")` was applied per-site to silence a compiler warning about an unused parameter in `registerExtensions`. This annotation approach is fragile — it must be remembered at every call site and couples source files to specific warning categories.

## Modification

- Removed the per-site `@nowarn` annotation from `CodeGenerator.scala` (Scala 2.12 version)
- Added a precise, scoped compiler option `-Wconf:src=.*/grpc/gen/CodeGenerator\.scala:msg=is never used:silent` to `project/Common.scala`, targeting only the specific file and message pattern

## Result

The unused parameter warning is suppressed via compiler configuration instead of per-site annotations. This is more maintainable, less intrusive, and follows Scala compiler best practices.

## References

- Upstream commit (which is now Apache licensed): https://github.com/akka/akka-grpc/commit/46bd59ff
- Upstream PR: https://github.com/akka/akka-grpc/pull/1699
