### PR TITLE
chore: remove references to Play gRPC from docs

### DIFF
--- a/docs/src/main/paradox/buildtools/gradle.md
+++ b/docs/src/main/paradox/buildtools/gradle.md
@@ -106,6 +106,4 @@ Then, the server can then be started from the command line with:
 ./gradlew runServer
 ```
 
-## Play Framework support
 
-See the [Play gRPC documentation](https://github.com/playframework/play-grpc) for details.

--- a/docs/src/main/paradox/overview.md
+++ b/docs/src/main/paradox/overview.md
@@ -22,8 +22,7 @@ It features:
  * gRPC Runtime implementation that uses 
     - @extref[Pekko HTTP/2 support](pekko-http:server-side/http2.html) for the server side and 
     - `grpc-netty-shaded` for the client side.
- * Support for @ref[sbt](buildtools/sbt.md), @ref[gradle](buildtools/gradle.md), @ref[Maven](buildtools/maven.md),
-   and the [Play Framework](https://github.com/playframework/play-grpc).
+ * Support for @ref[sbt](buildtools/sbt.md), @ref[gradle](buildtools/gradle.md), and @ref[Maven](buildtools/maven.md).
 
 ## Project Information
 


### PR DESCRIPTION
## Motivation

Documentation for Pekko gRPC contained references to the Play gRPC project (`play-grpc`), a separate independent project that is not part of Pekko gRPC. These references may confuse users or imply integration support that does not exist in this project.

## Modification

- Removed the "Play Framework support" section from `docs/src/main/paradox/buildtools/gradle.md`
- Removed the `[Play Framework](...)` reference from the supported build tools list in `docs/src/main/paradox/overview.md`

## Result

Documentation now focuses solely on Pekko gRPC's own supported build tools (sbt, Gradle, Maven) without referring users to an unrelated external project.

## References

- Upstream commit (which is now Apache licensed): https://github.com/akka/akka-grpc/commit/8aa142b8
- Upstream PR: https://github.com/akka/akka-grpc/pull/1739
