### PR TITLE
Return more helpful error message when tmpdir is mounted noexec maven

### DIFF
--- a/maven-plugin/src/main/scala/org/apache/pekko/grpc/maven/AbstractGenerateMojo.scala
+++ b/maven-plugin/src/main/scala/org/apache/pekko/grpc/maven/AbstractGenerateMojo.scala
@@ -270,6 +270,12 @@ abstract class AbstractGenerateMojo @Inject() (buildContext: BuildContext) exten
               BuildContext.SEVERITY_ERROR,
               new RuntimeException("protoc compilation failed") with NoStackTrace)
           case Right(otherError) =>
+            if (otherError.contains("program not found or is not executable")) {
+              sys.error(
+                s"Could not execute the automatically downloaded protoc to compile protobuf files, check that the filesystem of " +
+                s"[${sys.props("java.io.tmpdir")}] is not mounted with the 'noexec' option, or specify an alternative directory allowing executables using the Java " +
+                "system property java.io.tmpdir when executing maven.")
+            }
             sys.error(s"protoc exit code $exitCode: $otherError")
         }
       } else {


### PR DESCRIPTION
Ports https://github.com/akka/akka-grpc/pull/1772 which is now Apache 2.0.