### PR TITLE
correct config for sbt-java-formatter 0.12.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -8,6 +8,7 @@
  */
 
 import com.github.pjfanning.pekkobuild._
+import com.github.sbt.JavaFormatterPlugin.autoImport.javafmtSortImports
 import net.bzzt.reproduciblebuilds.ReproducibleBuildsPlugin.reproducibleBuildsCheckResolver
 import org.apache.pekko.grpc.{ Dependencies, NoPublish, PekkoCoreDependency, PekkoHttpDependency }
 import org.apache.pekko.grpc.Dependencies.Versions.{ scala212, scala213 }
@@ -40,6 +41,8 @@ lazy val mkBatAssemblyTask = taskKey[File]("Create a Windows bat assembly")
 
 // gradle plugin compatibility (avoid `+` in snapshot versions)
 (ThisBuild / dynverSeparator) := "-"
+
+ThisBuild / javafmtFormatterCompatibleJavaVersion := 17
 
 val pekkoGrpcCodegenId = s"$pekkoPrefix-codegen"
 lazy val codegen = Project(id = "codegen", base = file("codegen"))
@@ -194,6 +197,7 @@ lazy val interopTests = Project(id = "interop-tests", base = file("interop-tests
   .pluginTestingSettings
   .settings(
     name := s"$pekkoPrefix-interop-tests",
+    javafmtSortImports := false,
     // All io.grpc servers want to bind to port :8080
     parallelExecution := false,
     ReflectiveCodeGen.generatedLanguages := Seq("Scala", "Java"),
@@ -311,6 +315,7 @@ lazy val pluginTesterJava = Project(id = "plugin-tester-java", base = file("plug
   .settings(Dependencies.pluginTester)
   .settings(
     name := s"$pekkoPrefix-plugin-tester-java",
+    javafmtSortImports := false,
     fork := true,
     PB.protocVersion := Dependencies.Versions.googleProtoc,
     ReflectiveCodeGen.generatedLanguages := Seq("Java"),

--- a/interop-tests/src/test/java/example/myapp/helloworld/grpc/ExceptionGreeterServiceImpl.java
+++ b/interop-tests/src/test/java/example/myapp/helloworld/grpc/ExceptionGreeterServiceImpl.java
@@ -13,64 +13,68 @@
 
 package example.myapp.helloworld.grpc;
 
-//#unary
+// #unary
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
-//#unary
+// #unary
 
-//#streaming
+// #streaming
 import org.apache.pekko.NotUsed;
 import org.apache.pekko.stream.javadsl.Source;
-//#streaming
+// #streaming
 
-//#unary
-//#streaming
+// #unary
+// #streaming
 
 import io.grpc.Status;
 import org.apache.pekko.grpc.GrpcServiceException;
 
-//#unary
-//#streaming
+// #unary
+// #streaming
 
 public class ExceptionGreeterServiceImpl implements GreeterService {
-    //#unary
-    // ...
+  // #unary
+  // ...
 
-    @Override
-    public CompletionStage<HelloReply> sayHello(HelloRequest in) {
-        if (in.getName().isEmpty()) {
-            CompletableFuture<HelloReply> future = new CompletableFuture<>();
-            future.completeExceptionally(new GrpcServiceException(Status.INVALID_ARGUMENT.withDescription("No name found")));
-            return future;
-        } else {
-            return CompletableFuture.completedFuture(HelloReply.newBuilder().setMessage("Hi, " + in.getName()).build());
-        }
+  @Override
+  public CompletionStage<HelloReply> sayHello(HelloRequest in) {
+    if (in.getName().isEmpty()) {
+      CompletableFuture<HelloReply> future = new CompletableFuture<>();
+      future.completeExceptionally(
+          new GrpcServiceException(Status.INVALID_ARGUMENT.withDescription("No name found")));
+      return future;
+    } else {
+      return CompletableFuture.completedFuture(
+          HelloReply.newBuilder().setMessage("Hi, " + in.getName()).build());
     }
-    //#unary
+  }
 
-    private Source<HelloReply, NotUsed> myResponseSource = null;
-    
-    //#streaming
-    // ...
+  // #unary
 
-    @Override
-    public Source<HelloReply, NotUsed> itKeepsReplying(HelloRequest in) {
-      if (in.getName().isEmpty()) {
-            return Source.failed(new GrpcServiceException(Status.INVALID_ARGUMENT.withDescription("No name found")));
-        } else {
-            return myResponseSource;
-        }
+  private Source<HelloReply, NotUsed> myResponseSource = null;
+
+  // #streaming
+  // ...
+
+  @Override
+  public Source<HelloReply, NotUsed> itKeepsReplying(HelloRequest in) {
+    if (in.getName().isEmpty()) {
+      return Source.failed(
+          new GrpcServiceException(Status.INVALID_ARGUMENT.withDescription("No name found")));
+    } else {
+      return myResponseSource;
     }
-    //#streaming
+  }
 
-    @Override
-    public Source<HelloReply, NotUsed> streamHellos(Source<HelloRequest,NotUsed> in) {
-        return null;
-    }
+  // #streaming
 
-    @Override
-    public CompletionStage<HelloReply> itKeepsTalking(Source<HelloRequest, NotUsed> in) {
-        return null;
-    }
-    
+  @Override
+  public Source<HelloReply, NotUsed> streamHellos(Source<HelloRequest, NotUsed> in) {
+    return null;
+  }
+
+  @Override
+  public CompletionStage<HelloReply> itKeepsTalking(Source<HelloRequest, NotUsed> in) {
+    return null;
+  }
 }

--- a/interop-tests/src/test/java/org/apache/pekko/grpc/interop/JavaTestServiceImpl.java
+++ b/interop-tests/src/test/java/org/apache/pekko/grpc/interop/JavaTestServiceImpl.java
@@ -32,25 +32,26 @@ import io.grpc.testing.integration.TestService;
 /**
  * Implementation of the generated service.
  *
- * Essentially porting the client code from [[io.grpc.testing.integration.TestServiceImpl]] against our API's
+ * <p>Essentially porting the client code from [[io.grpc.testing.integration.TestServiceImpl]]
+ * against our API's
  *
- * The same implementation is also be found as part of the 'scripted' tests at
+ * <p>The same implementation is also be found as part of the 'scripted' tests at
  * /sbt-plugin/src/sbt-test/gen-scala-server/00-interop/src/main/java/org/apache/pekko/grpc/JavaTestServiceImpl.scala
  */
 public class JavaTestServiceImpl implements TestService {
   private final Materializer mat;
 
-  private static final Flow<ResponseParameters, StreamingOutputCallResponse, NotUsed> parametersToResponseFlow =
-    Flow.<ResponseParameters>create()
-      .map(parameters ->
-      StreamingOutputCallResponse.newBuilder()
-        .setPayload(
-          Payload.newBuilder()
-            .setBody(ByteString.copyFrom(new byte[parameters.getSize()]))
-            .build()
-        )
-        .build()
-    );
+  private static final Flow<ResponseParameters, StreamingOutputCallResponse, NotUsed>
+      parametersToResponseFlow =
+          Flow.<ResponseParameters>create()
+              .map(
+                  parameters ->
+                      StreamingOutputCallResponse.newBuilder()
+                          .setPayload(
+                              Payload.newBuilder()
+                                  .setBody(ByteString.copyFrom(new byte[parameters.getSize()]))
+                                  .build())
+                          .build());
 
   public JavaTestServiceImpl(Materializer mat) {
     this.mat = mat;
@@ -61,24 +62,25 @@ public class JavaTestServiceImpl implements TestService {
     return CompletableFuture.completedFuture(EmptyProtos.Empty.newBuilder().build());
   }
 
-    @Override
-    public CompletionStage<SimpleResponse> unaryCall(SimpleRequest in) {
-        if (in.hasResponseStatus()) {
-            EchoStatus requestStatus = in.getResponseStatus();
-            Status status = Status.fromCodeValue(requestStatus.getCode()).withDescription(requestStatus.getMessage());
-            CompletableFuture<SimpleResponse> cf = new CompletableFuture<>();
-            cf.completeExceptionally(new GrpcServiceException(status));
-            return cf;
-        } else {
-            return CompletableFuture.completedFuture(
-                    SimpleResponse.newBuilder()
-                            .setPayload(Payload.newBuilder()
-                                    .setBody(ByteString.copyFrom(new byte[in.getResponseSize()]))
-                                    .build())
-                            .build()
-            );
-        }
+  @Override
+  public CompletionStage<SimpleResponse> unaryCall(SimpleRequest in) {
+    if (in.hasResponseStatus()) {
+      EchoStatus requestStatus = in.getResponseStatus();
+      Status status =
+          Status.fromCodeValue(requestStatus.getCode()).withDescription(requestStatus.getMessage());
+      CompletableFuture<SimpleResponse> cf = new CompletableFuture<>();
+      cf.completeExceptionally(new GrpcServiceException(status));
+      return cf;
+    } else {
+      return CompletableFuture.completedFuture(
+          SimpleResponse.newBuilder()
+              .setPayload(
+                  Payload.newBuilder()
+                      .setBody(ByteString.copyFrom(new byte[in.getResponseSize()]))
+                      .build())
+              .build());
     }
+  }
 
   @Override
   public CompletionStage<SimpleResponse> cacheableUnaryCall(SimpleRequest in) {
@@ -86,48 +88,47 @@ public class JavaTestServiceImpl implements TestService {
   }
 
   @Override
-  public Source<StreamingOutputCallResponse, NotUsed> streamingOutputCall(StreamingOutputCallRequest in) {
+  public Source<StreamingOutputCallResponse, NotUsed> streamingOutputCall(
+      StreamingOutputCallRequest in) {
     return Source.from(in.getResponseParametersList())
-      .via(parametersToResponseFlow)
-      .mapMaterializedValue(x -> x);
+        .via(parametersToResponseFlow)
+        .mapMaterializedValue(x -> x);
   }
 
   @Override
-  public CompletionStage<StreamingInputCallResponse> streamingInputCall(Source<StreamingInputCallRequest, NotUsed> in) {
-    return in
-      .map(i -> i.getPayload().getBody().size())
-      .runFold(0, (Integer x, Integer y)->x+y, mat)
-      .thenApply(sum -> StreamingInputCallResponse.newBuilder().setAggregatedPayloadSize(sum).build());
+  public CompletionStage<StreamingInputCallResponse> streamingInputCall(
+      Source<StreamingInputCallRequest, NotUsed> in) {
+    return in.map(i -> i.getPayload().getBody().size())
+        .runFold(0, (Integer x, Integer y) -> x + y, mat)
+        .thenApply(
+            sum -> StreamingInputCallResponse.newBuilder().setAggregatedPayloadSize(sum).build());
   }
 
-
   @Override
-  public Source<StreamingOutputCallResponse, NotUsed> fullDuplexCall(Source<StreamingOutputCallRequest, NotUsed> in) {
-    return in
-            .map(req -> {
-                if(req.hasResponseStatus()) {
-                    throw new GrpcServiceException(
-                            Status
-                                    .fromCodeValue(req.getResponseStatus().getCode())
-                                    .withDescription(req.getResponseStatus().getMessage())
-                    );
-                }else {
-                    return req;
-                }
+  public Source<StreamingOutputCallResponse, NotUsed> fullDuplexCall(
+      Source<StreamingOutputCallRequest, NotUsed> in) {
+    return in.map(
+            req -> {
+              if (req.hasResponseStatus()) {
+                throw new GrpcServiceException(
+                    Status.fromCodeValue(req.getResponseStatus().getCode())
+                        .withDescription(req.getResponseStatus().getMessage()));
+              } else {
+                return req;
+              }
             })
-      .mapConcat(r -> r.getResponseParametersList())
-      .via(parametersToResponseFlow);
+        .mapConcat(r -> r.getResponseParametersList())
+        .via(parametersToResponseFlow);
   }
 
-
   @Override
-  public Source<StreamingOutputCallResponse, NotUsed> halfDuplexCall(Source<StreamingOutputCallRequest, NotUsed> in) {
+  public Source<StreamingOutputCallResponse, NotUsed> halfDuplexCall(
+      Source<StreamingOutputCallRequest, NotUsed> in) {
     return null;
   }
 
   @Override
   public CompletionStage<EmptyProtos.Empty> unimplementedCall(EmptyProtos.Empty in) {
-     throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException();
   }
-
 }

--- a/plugin-tester-java/src/main/java/example/myapp/CombinedServer.java
+++ b/plugin-tester-java/src/main/java/example/myapp/CombinedServer.java
@@ -23,18 +23,18 @@ import com.typesafe.config.ConfigFactory;
 import java.util.Arrays;
 import java.util.concurrent.CompletionStage;
 
-//#import
+// #import
 import org.apache.pekko.grpc.javadsl.ServiceHandler;
 import org.apache.pekko.http.javadsl.model.HttpRequest;
 import org.apache.pekko.http.javadsl.model.HttpResponse;
 import org.apache.pekko.japi.function.Function;
 
-//#import
+// #import
 
-//#grpc-web
+// #grpc-web
 import org.apache.pekko.grpc.javadsl.WebHandler;
 
-//#grpc-web
+// #grpc-web
 
 import example.myapp.helloworld.*;
 import example.myapp.helloworld.grpc.*;
@@ -43,36 +43,38 @@ import example.myapp.echo.grpc.*;
 
 class CombinedServer {
   public static void main(String[] args) {
-      // important to enable HTTP/2 in ActorSystem's config
-      Config conf = ConfigFactory.parseString("pekko.http.server.enable-http2 = on")
-        .withFallback(ConfigFactory.defaultApplication());
-      ActorSystem sys = ActorSystem.create("HelloWorld", conf);
-      Materializer mat = SystemMaterializer.get(sys).materializer();
+    // important to enable HTTP/2 in ActorSystem's config
+    Config conf =
+        ConfigFactory.parseString("pekko.http.server.enable-http2 = on")
+            .withFallback(ConfigFactory.defaultApplication());
+    ActorSystem sys = ActorSystem.create("HelloWorld", conf);
+    Materializer mat = SystemMaterializer.get(sys).materializer();
 
-      //#concatOrNotFound
-      Function<HttpRequest, CompletionStage<HttpResponse>> greeterService =
-          GreeterServiceHandlerFactory.create(new GreeterServiceImpl(mat), sys);
-      Function<HttpRequest, CompletionStage<HttpResponse>> echoService =
+    // #concatOrNotFound
+    Function<HttpRequest, CompletionStage<HttpResponse>> greeterService =
+        GreeterServiceHandlerFactory.create(new GreeterServiceImpl(mat), sys);
+    Function<HttpRequest, CompletionStage<HttpResponse>> echoService =
         EchoServiceHandlerFactory.create(new EchoServiceImpl(), sys);
-      @SuppressWarnings("unchecked")
-      Function<HttpRequest, CompletionStage<HttpResponse>> serviceHandlers =
+    @SuppressWarnings("unchecked")
+    Function<HttpRequest, CompletionStage<HttpResponse>> serviceHandlers =
         ServiceHandler.concatOrNotFound(greeterService, echoService);
 
-      Http.get(sys)
-          .newServerAt("127.0.0.1", 8090)
-          .bind(serviceHandlers)
-      //#concatOrNotFound
-      .thenAccept(binding -> System.out.println("gRPC server bound to: " + binding.localAddress()));
+    Http.get(sys)
+        .newServerAt("127.0.0.1", 8090)
+        .bind(serviceHandlers)
+        // #concatOrNotFound
+        .thenAccept(
+            binding -> System.out.println("gRPC server bound to: " + binding.localAddress()));
 
-      //#grpc-web
-      Function<HttpRequest, CompletionStage<HttpResponse>> grpcWebServiceHandlers =
-          WebHandler.grpcWebHandler(Arrays.asList(greeterService, echoService), sys, mat);
+    // #grpc-web
+    Function<HttpRequest, CompletionStage<HttpResponse>> grpcWebServiceHandlers =
+        WebHandler.grpcWebHandler(Arrays.asList(greeterService, echoService), sys, mat);
 
-      Http.get(sys)
+    Http.get(sys)
         .newServerAt("127.0.0.1", 8090)
         .bind(grpcWebServiceHandlers)
-      //#grpc-web
-      .thenAccept(binding -> System.out.println("gRPC-Web server bound to: " + binding.localAddress()));
-
+        // #grpc-web
+        .thenAccept(
+            binding -> System.out.println("gRPC-Web server bound to: " + binding.localAddress()));
   }
 }


### PR DESCRIPTION
- follow up to #684

See https://github.com/sbt/sbt-java-formatter/releases/tag/v0.12.0

Currently two things are broken:
1. `javafmt[All]` will not run on java 17, fixed by `javafmtFormatterCompatibleJavaVersion := 17`
2. three files are will not format out of the box anymore (fixed by `javafmtSortImports := false`):
```
sbt:pekko-grpc-root> javafmtAll
[info] Formatting 1 Java source...
[error] ./plugin-tester-java/src/main/java/example/myapp/CombinedServer.java:error: Imports not contiguous (perhaps a comment separates them?)
[info] Formatting 2 Java sources...
[error] ./interop-tests/src/test/java/example/myapp/helloworld/grpc/ExceptionGreeterServiceImpl.java:error: Imports not contiguous (perhaps a comment separates them?)
[error] ./interop-tests/src/test/java/org/apache/pekko/grpc/interop/JavaTestServiceImpl.java:error: Imports not contiguous (perhaps a comment separates them?)
[error] google-java-format check failed
[error] google-java-format check failed
[error] (plugin-tester-java / Compile / javafmt) google-java-format check failed
[error] (interop-tests / Test / javafmt) google-java-format check failed
```