### PR TITLE
fix: clean up Netty SSL context creation

### DIFF
--- a/runtime/src/main/scala/org/apache/pekko/grpc/internal/NettyClientUtils.scala
+++ b/runtime/src/main/scala/org/apache/pekko/grpc/internal/NettyClientUtils.scala
@@ -183,22 +183,25 @@ object NettyClientUtils {
    */
   @InternalApi
   private def createNettySslContext(javaSslContext: SSLContext): SslContext = {
-    import io.grpc.netty.shaded.io.netty.handler.ssl.{ JdkSslContext, SslProvider }
-    import java.lang.reflect.Field
-
-    // This is a hack for situations where the SSLContext is given.
-    // This approach forces using SslProvider.JDK.
-
-    // Create a Netty JdkSslContext object with all the correct ciphers, protocol settings, etc initialized.
-    val nettySslContext: JdkSslContext =
-      GrpcSslContexts.configure(GrpcSslContexts.forClient, SslProvider.JDK).build.asInstanceOf[JdkSslContext]
-
-    // Patch the SSLContext value inside the JdkSslContext object
-    val nettySslContextField: Field = classOf[JdkSslContext].getDeclaredField("sslContext")
-    nettySslContextField.setAccessible(true)
-    nettySslContextField.set(nettySslContext, javaSslContext)
-
-    nettySslContext
+    import io.grpc.netty.shaded.io.netty.handler.ssl.{ ApplicationProtocolConfig, ClientAuth, JdkSslContext }
+    import io.grpc.netty.shaded.io.netty.handler.codec.http2.Http2SecurityUtil
+    import io.grpc.netty.shaded.io.netty.handler.ssl.SupportedCipherSuiteFilter
+    // See
+    // https://github.com/netty/netty/blob/4.1/handler/src/main/java/io/netty/handler/ssl/JdkSslContext.java#L229-L309
+    new JdkSslContext(
+      javaSslContext,
+      /* boolean isClient */ true,
+      // Keep HTTP/2 ciphers and ALPN so Java SSLContext-backed clients negotiate h2.
+      /* Iterable<String> ciphers */ Http2SecurityUtil.CIPHERS,
+      SupportedCipherSuiteFilter.INSTANCE,
+      /* ApplicationProtocolConfig apn */ new ApplicationProtocolConfig(
+        ApplicationProtocolConfig.Protocol.ALPN,
+        ApplicationProtocolConfig.SelectorFailureBehavior.NO_ADVERTISE,
+        ApplicationProtocolConfig.SelectedListenerFailureBehavior.ACCEPT,
+        "h2"),
+      ClientAuth.NONE, // server-only option, which is ignored as isClient=true (as indicated in constructor Javadoc)
+      /* String[] protocols */ null, // use JDK defaults (null is accepted as indicated in constructor Javadoc)
+      /* boolean startTls */ false)
   }
 
   /**


### PR DESCRIPTION
Motivation:
Port the applicable behavior from akka/akka-grpc commit b0ff79ecc4382b25bad4e041df6cdbaa3b305343, which is now Apache licensed.

The upstream change removes reflective mutation of Netty `JdkSslContext` internals when adapting a Java `SSLContext` for gRPC clients.

Modification:
- Replace the reflection-based `sslContext` field patching in `NettyClientUtils#createNettySslContext` with direct `JdkSslContext` construction.
- Keep HTTP/2 ciphers and ALPN `h2` enabled for the current grpc-netty-shaded runtime, preserving TLS/HTTP2 negotiation behavior.

Result:
Java `SSLContext`-backed clients no longer rely on private Netty internals while continuing to negotiate HTTP/2 correctly.

Validation:
- `sbt --batch "runtime/scalafmtCheck" "runtime/testOnly org.apache.pekko.grpc.internal.NettyClientUtilsSpec" "plugin-tester-scala/testOnly example.myapp.helloworld.MtlsIntegrationSpec"`
- Combined local final check also passed: `sbt --batch scalafmtCheckAll test`

References:
- Upstream commit: https://github.com/akka/akka-grpc/commit/b0ff79ecc4382b25bad4e041df6cdbaa3b305343
- Upstream PR: https://github.com/akka/akka-grpc/pull/1649
