### PR TITLE
docs: remove Play gRPC references

### DIFF
--- a/docs/src/main/paradox/buildtools/gradle.md
+++ b/docs/src/main/paradox/buildtools/gradle.md
@@ -105,7 +105,3 @@ Then, the server can then be started from the command line with:
 ```
 ./gradlew runServer
 ```
-
-## Play Framework support
-
-See the [Play gRPC documentation](https://github.com/playframework/play-grpc) for details.

--- a/docs/src/main/paradox/overview.md
+++ b/docs/src/main/paradox/overview.md
@@ -22,8 +22,7 @@ It features:
  * gRPC Runtime implementation that uses 
     - @extref[Pekko HTTP/2 support](pekko-http:server-side/http2.html) for the server side and 
     - `grpc-netty-shaded` for the client side.
- * Support for @ref[sbt](buildtools/sbt.md), @ref[gradle](buildtools/gradle.md), @ref[Maven](buildtools/maven.md),
-   and the [Play Framework](https://github.com/playframework/play-grpc).
+ * Support for @ref[sbt](buildtools/sbt.md), @ref[gradle](buildtools/gradle.md), and @ref[Maven](buildtools/maven.md).
 
 ## Project Information
 


### PR DESCRIPTION
Motivation:
Port the applicable documentation cleanup from akka/akka-grpc commit 8aa142b8b1158cde7232438b57e0818bf72546f6, which is now Apache licensed.

The upstream change removes stale Play gRPC references from the gRPC documentation.

Modification:
- Remove the Play Framework support section from the Gradle documentation.
- Keep the overview build-tool list focused on sbt, Gradle, and Maven for Pekko gRPC.

Result:
Pekko gRPC docs no longer suggest Play gRPC as part of the supported setup path.

Validation:
- `grep -RInE 'Play Framework|Play gRPC|play-grpc' docs/src/main/paradox` returned no matches.
- `sbt --batch docs/paradox`
- Combined local final check also passed: `sbt --batch scalafmtCheckAll test`

References:
- Upstream commit: https://github.com/akka/akka-grpc/commit/8aa142b8b1158cde7232438b57e0818bf72546f6
- Upstream PR: https://github.com/akka/akka-grpc/pull/1739
