### PR TITLE
replace scala string interpolation in logging

### DIFF
--- a/maven-plugin/src/main/scala/org/apache/pekko/grpc/maven/AbstractGenerateMojo.scala
+++ b/maven-plugin/src/main/scala/org/apache/pekko/grpc/maven/AbstractGenerateMojo.scala
@@ -253,11 +253,15 @@ abstract class AbstractGenerateMojo @Inject() (buildContext: BuildContext) exten
       .sortBy(_.outputPath.getAbsolutePath.length)
     generatedTargets.foreach(_.outputPath.mkdirs())
     if (schemas.nonEmpty && generatedTargets.nonEmpty) {
-      getLog.info(
-        "Compiling %d protobuf files to %s".format(schemas.size, generatedTargets.map(_.outputPath).mkString(",")))
+      if (getLog.isInfoEnabled) {
+        getLog.info(
+          "Compiling %d protobuf files to %s".format(schemas.size, generatedTargets.map(_.outputPath).mkString(",")))
+      }
       schemas.foreach { schema => buildContext.removeMessages(schema) }
-      getLog.debug("Compiling schemas [%s]".format(schemas.mkString(",")))
-      getLog.debug("protoc options: %s".format(protocOptions.mkString(",")))
+      if (getLog.isDebugEnabled) {
+        getLog.debug("Compiling schemas [%s]".format(schemas.mkString(",")))
+        getLog.debug("protoc options: %s".format(protocOptions.mkString(",")))
+      }
 
       getLog.info("Compiling protobuf")
       val (out, err, exitCode) = captureStdOutAndErr {

--- a/runtime/src/main/scala/org/apache/pekko/grpc/internal/ChannelUtils.scala
+++ b/runtime/src/main/scala/org/apache/pekko/grpc/internal/ChannelUtils.scala
@@ -75,7 +75,7 @@ object ChannelUtils {
       maxConnectionAttempts: Option[Int],
       log: LoggingAdapter): Unit = {
     def monitor(currentState: ConnectivityState, connectionAttempts: Int): Unit = {
-      log.debug(s"monitoring with state $currentState and connectionAttempts $connectionAttempts")
+      log.debug("monitoring with state {} and connectionAttempts {}", currentState, connectionAttempts)
       val newAttemptOpt = currentState match {
         case ConnectivityState.TRANSIENT_FAILURE =>
           if (maxConnectionAttempts.contains(connectionAttempts + 1)) {


### PR DESCRIPTION
also guard logging statements that have non-trivial evaluations to derive their log statements