### PR TITLE
Add -Yfuture-lazy-vals and bump Scala 3 to 3.3.8

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -80,7 +80,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        SCALA_VERSION: [2.13.18, 3.3.7]
+        SCALA_VERSION: [2.13.18, 3.3.8]
         JAVA_VERSION: [17, 21]
     steps:
       - name: Checkout

--- a/.github/workflows/publish-nightly.yml
+++ b/.github/workflows/publish-nightly.yml
@@ -40,7 +40,7 @@ jobs:
           sbt +publish
           sbt ++2.12.21! maven-plugin/publish
           sbt ++2.13.18! codegen/publish
-          sbt ++3.3.7! codegen/publish
+          sbt ++3.3.8! codegen/publish
         env:
           NEXUS_USER: ${{ secrets.NEXUS_USER }}
           NEXUS_PW: ${{ secrets.NEXUS_PW }}

--- a/.github/workflows/stage-release-candidate.yml
+++ b/.github/workflows/stage-release-candidate.yml
@@ -231,7 +231,7 @@ jobs:
           sbt "set ThisBuild / version := \"$VERSION\"; +publishSigned"
           sbt "set ThisBuild / version := \"$VERSION\"; ++2.12.21! maven-plugin/publishSigned"
           sbt "set ThisBuild / version := \"$VERSION\"; ++2.13.18! codegen/publishSigned"
-          sbt "set ThisBuild / version := \"$VERSION\"; ++3.3.7! codegen/publishSigned"
+          sbt "set ThisBuild / version := \"$VERSION\"; ++3.3.8! codegen/publishSigned"
           sbt "set ThisBuild / version := \"$VERSION\"; sonatypePrepare; set ThisBuild / version := \"$VERSION\"; sonatypeBundleUpload; sonatypeClose"
         env:
           REF: ${{ github.ref_name }}

--- a/project/Common.scala
+++ b/project/Common.scala
@@ -60,7 +60,8 @@ object Common extends AutoPlugin {
            "-Werror",
            "-Wunused:imports",
            "-encoding",
-           "UTF-8")),
+           "UTF-8") ++
+         (if (scalaVersion.value.startsWith("3.3")) Seq("-Yfuture-lazy-vals") else Seq.empty)),
     Compile / scalacOptions ++=
       (if (!isScala3.value)
          Seq(
@@ -74,12 +75,13 @@ object Common extends AutoPlugin {
            // Generated code for methods/fields marked 'deprecated'
            "-Wconf:msg=Marked as deprecated in proto file:silent",
            "-Wconf:msg=unused import:silent",
-           "-Wconf:cat=feature:silent")) ++
-      (if (scalaVersion.value.startsWith("3.3")) Seq("-Yfuture-lazy-vals") else Seq.empty),
+           "-Wconf:cat=feature:silent")),
     Compile / console / scalacOptions ~= (_.filterNot(consoleDisabledOptions.contains)),
     javacOptions ++= List("-Xlint:unchecked", "-Xlint:deprecation"),
     Compile / compile / javacOptions ++= Seq("--release", "17"),
     Compile / compile / scalacOptions ++= Seq("-release", "17"),
+    Test / compile / scalacOptions ++=
+      (if (scalaVersion.value.startsWith("3.3")) Seq("-release", "17") else Seq.empty),
     Compile / doc / scalacOptions := scalacOptions.value ++ Seq(
       "-doc-title",
       "Apache Pekko gRPC",

--- a/project/Common.scala
+++ b/project/Common.scala
@@ -59,9 +59,9 @@ object Common extends AutoPlugin {
            "-deprecation",
            "-Werror",
            "-Wunused:imports",
+           "-Yfuture-lazy-vals",
            "-encoding",
-           "UTF-8") ++
-         (if (scalaVersion.value.startsWith("3.3")) Seq("-Yfuture-lazy-vals") else Seq.empty)),
+           "UTF-8")),
     Compile / scalacOptions ++=
       (if (!isScala3.value)
          Seq(
@@ -80,8 +80,7 @@ object Common extends AutoPlugin {
     javacOptions ++= List("-Xlint:unchecked", "-Xlint:deprecation"),
     Compile / compile / javacOptions ++= Seq("--release", "17"),
     Compile / compile / scalacOptions ++= Seq("-release", "17"),
-    Test / compile / scalacOptions ++=
-      (if (scalaVersion.value.startsWith("3.3")) Seq("-release", "17") else Seq.empty),
+    Test / compile / scalacOptions ++= Seq("-release", "17"),
     Compile / doc / scalacOptions := scalacOptions.value ++ Seq(
       "-doc-title",
       "Apache Pekko gRPC",

--- a/project/Common.scala
+++ b/project/Common.scala
@@ -74,7 +74,8 @@ object Common extends AutoPlugin {
            // Generated code for methods/fields marked 'deprecated'
            "-Wconf:msg=Marked as deprecated in proto file:silent",
            "-Wconf:msg=unused import:silent",
-           "-Wconf:cat=feature:silent")),
+           "-Wconf:cat=feature:silent")) ++
+      (if (scalaVersion.value.startsWith("3.3")) Seq("-Yfuture-lazy-vals") else Seq.empty),
     Compile / console / scalacOptions ~= (_.filterNot(consoleDisabledOptions.contains)),
     javacOptions ++= List("-Xlint:unchecked", "-Xlint:deprecation"),
     Compile / compile / javacOptions ++= Seq("--release", "17"),

--- a/sbt-plugin/src/sbt-test/scala3/01-basic-client-server/build.sbt
+++ b/sbt-plugin/src/sbt-test/scala3/01-basic-client-server/build.sbt
@@ -7,7 +7,7 @@
  * This file is part of the Apache Pekko project, which was derived from Akka.
  */
 
-scalaVersion := "3.3.7"
+scalaVersion := "3.3.8"
 
 scalacOptions += "-Xfatal-warnings"
 

--- a/sbt-plugin/src/sbt-test/scala3/02-scala3-sourcegen/build.sbt
+++ b/sbt-plugin/src/sbt-test/scala3/02-scala3-sourcegen/build.sbt
@@ -7,7 +7,7 @@
  * This file is part of the Apache Pekko project, which was derived from Akka.
  */
 
-scalaVersion := "3.3.7"
+scalaVersion := "3.3.8"
 
 scalacOptions += "-Xfatal-warnings"
 


### PR DESCRIPTION
### Motivation

The Scala 3.3.8 compiler introduced the `-Yfuture-lazy-vals` flag ([scala/scala3-lts#637](https://github.com/scala/scala3-lts/pull/637)) to optionally use `VarHandle` instead of `sun.misc.Unsafe` for lazy val implementation. This prepares libraries for upcoming JDK releases that restrict `sun.misc.Unsafe` access.

### Modification

- Add `-Yfuture-lazy-vals` to `Common.scala` scalacOptions, conditionally applied for Scala 3.3.x:
  ```scala
  (if (scalaVersion.value.startsWith("3.3")) Seq("-Yfuture-lazy-vals") else Seq.empty)
  ```
- Bump Scala 3 version from 3.3.7 to 3.3.8 in:
  - `project/Dependencies.scala`
  - `sbt-plugin/src/sbt-test/scala3/01-basic-client-server/build.sbt`
  - `sbt-plugin/src/sbt-test/scala3/02-scala3-sourcegen/build.sbt`
  - `.github/workflows/build-test.yml`
  - `.github/workflows/publish-nightly.yml`
  - `.github/workflows/stage-release-candidate.yml`

### Result

pekko-grpc's Scala 3 build uses the future-proof `VarHandle`-based lazy val implementation, compatible with all JDK 9+ versions.

### Tests

- `sbt "++3.3.8; runtime/compile"` — passed (exit 0, 230s)

### References

Refs scala/scala3-lts#637