### PR TITLE
chore: Rewrite to scala3 syntax

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,5 +1,5 @@
 version                                  = 3.11.1
-runner.dialect                           = scala213
+runner.dialect                           = scala213source3
 project.git                              = true
 style                                    = defaultWithAlign
 docstrings.style                         = Asterisk
@@ -78,5 +78,15 @@ project.layout         = StandardConvention
 fileOverride           = {
   "glob:**/sbt-plugin/src/sbt-test/scala3/**" {
     runner.dialect = scala3
+  }
+}
+
+rewrite.scala3.convertToNewSyntax = true
+runner {
+  dialectOverride {
+    allowSignificantIndentation = false
+    allowAsForImportRename = false
+    allowStarWildcardImport = false
+    allowPostfixStarVarargSplices = false
   }
 }

--- a/interop-tests/src/main/scala/org/apache/pekko/grpc/interop/GrpcInteropTests.scala
+++ b/interop-tests/src/main/scala/org/apache/pekko/grpc/interop/GrpcInteropTests.scala
@@ -123,7 +123,7 @@ trait GrpcServerProvider {
   def label: String
   def pendingCases: Set[String]
 
-  def server: GrpcServer[_]
+  def server: GrpcServer[?]
 }
 
 trait GrpcClientProvider {

--- a/interop-tests/src/test/scala/org/apache/pekko/grpc/interop/PekkoGrpcScalaClientTester.scala
+++ b/interop-tests/src/test/scala/org/apache/pekko/grpc/interop/PekkoGrpcScalaClientTester.scala
@@ -276,13 +276,13 @@ class PekkoGrpcScalaClientTester(val settings: Settings, backend: String, testWi
   def timeoutOnSleepingServer(): Unit =
     throw new RuntimeException("Not implemented!timeoutOnSleepingServer") with NoStackTrace
 
-  def assertFailure(failure: Future[_], expectedStatus: Status): Unit = {
+  def assertFailure(failure: Future[?], expectedStatus: Status): Unit = {
     val throwable = Await.result(failure.failed, awaitTimeout)
     throwable shouldBe a[StatusRuntimeException]
     assertEquals(expectedStatus.getCode, throwable.asInstanceOf[StatusRuntimeException].getStatus.getCode)
   }
 
-  def assertFailure(failure: Future[_], expectedStatus: Status, expectedMessage: String): Unit = {
+  def assertFailure(failure: Future[?], expectedStatus: Status, expectedMessage: String): Unit = {
     val throwable = Await.result(failure.failed, awaitTimeout)
     throwable shouldBe a[StatusRuntimeException]
     val e = throwable.asInstanceOf[StatusRuntimeException]

--- a/interop-tests/src/test/scala/org/apache/pekko/grpc/scaladsl/GrpcMarshallingSpec.scala
+++ b/interop-tests/src/test/scala/org/apache/pekko/grpc/scaladsl/GrpcMarshallingSpec.scala
@@ -109,7 +109,7 @@ class GrpcMarshallingSpec extends AnyWordSpec with Matchers {
       assertFailure(GrpcMarshalling.unmarshal(request), Status.Code.INTERNAL, "encoding")
     }
 
-    def assertFailure(failure: Future[_], expectedStatusCode: Status.Code, expectedMessageFragment: String): Unit = {
+    def assertFailure(failure: Future[?], expectedStatusCode: Status.Code, expectedMessageFragment: String): Unit = {
       val e = Await.result(failure.failed, awaitTimeout).asInstanceOf[StatusException]
       e.getStatus.getCode should be(expectedStatusCode)
       e.getStatus.getDescription should include(expectedMessageFragment)

--- a/plugin-tester-scala/src/main/scala/example/myapp/typedhelloworld/GreeterServiceImpl.scala
+++ b/plugin-tester-scala/src/main/scala/example/myapp/typedhelloworld/GreeterServiceImpl.scala
@@ -24,7 +24,7 @@ import scala.concurrent.duration._
 import scala.concurrent.{ ExecutionContext, Future }
 
 // #stateful-service
-class GreeterServiceImpl(greeterActor: ActorRef[GreeterActor.GreetingCommand])(implicit system: ActorSystem[_])
+class GreeterServiceImpl(greeterActor: ActorRef[GreeterActor.GreetingCommand])(implicit system: ActorSystem[?])
     extends GreeterService {
 
   def sayHello(in: HelloRequest): Future[HelloReply] = {

--- a/project/ReflectiveCodeGen.scala
+++ b/project/ReflectiveCodeGen.scala
@@ -33,7 +33,7 @@ object ReflectiveCodeGen extends AutoPlugin {
   // needed to be able to override the PB.generate task reliably
   override lazy val requires = ProtocPlugin
 
-  override lazy val projectSettings: Seq[Def.Setting[_]] =
+  override lazy val projectSettings: Seq[Def.Setting[?]] =
     inConfig(Compile)(
       Seq(
         PB.protocOptions := protocOptions.value,

--- a/project/SbtMavenPlugin.scala
+++ b/project/SbtMavenPlugin.scala
@@ -32,7 +32,7 @@ object SbtMavenPlugin extends AutoPlugin {
 
   import autoImport._
 
-  override lazy val projectSettings: Seq[Setting[_]] = inConfig(Compile)(unscopedSettings)
+  override lazy val projectSettings: Seq[Setting[?]] = inConfig(Compile)(unscopedSettings)
 
   lazy val unscopedSettings =
     Seq(

--- a/project/VersionGenerator.scala
+++ b/project/VersionGenerator.scala
@@ -17,7 +17,7 @@ import sbt._
  */
 object VersionGenerator {
 
-  lazy val settings: Seq[Setting[_]] = inConfig(Compile)(
+  lazy val settings: Seq[Setting[?]] = inConfig(Compile)(
     Seq(
       resourceGenerators += generateVersion(resourceManaged, _ / "pekko-grpc-version.conf",
         """|pekko.grpc.version = "%s"

--- a/runtime/src/main/scala/org/apache/pekko/grpc/internal/GrpcProtocolNative.scala
+++ b/runtime/src/main/scala/org/apache/pekko/grpc/internal/GrpcProtocolNative.scala
@@ -63,7 +63,7 @@ object GrpcProtocolNative extends AbstractGrpcProtocol("grpc") {
       headers = headers,
       entity = HttpEntity(contentType, encodeDataToFrameBytes(codec, data)),
       protocol = HttpProtocols.`HTTP/1.1`,
-      attributes = Map.empty[AttributeKey[_], Any].updated(AttributeKeys.trailer, trailer))
+      attributes = Map.empty[AttributeKey[?], Any].updated(AttributeKeys.trailer, trailer))
 
   private def encodeDataToFrameBytes(codec: Codec, data: ByteString): ByteString =
     AbstractGrpcProtocol.encodeFrameData(codec.compress(data), codec.isCompressed, isTrailer = false)

--- a/runtime/src/main/scala/org/apache/pekko/grpc/internal/GrpcResponseHelpers.scala
+++ b/runtime/src/main/scala/org/apache/pekko/grpc/internal/GrpcResponseHelpers.scala
@@ -50,7 +50,7 @@ object GrpcResponseHelpers {
   private val TrailerOk = GrpcEntityHelpers.trailer(Status.OK)
   private val TrailerOkAttribute = Trailer(TrailerOk.trailers)
   private val TrailerOkAttributes =
-    Map.empty[AttributeKey[_], Any].updated(AttributeKeys.trailer, TrailerOkAttribute)
+    Map.empty[AttributeKey[?], Any].updated(AttributeKeys.trailer, TrailerOkAttribute)
   private val IdentityResponseHeaders: immutable.Seq[HttpHeader] =
     headers.`Message-Encoding`(Identity.name) :: Nil
 

--- a/runtime/src/main/scala/org/apache/pekko/grpc/javadsl/GrpcMarshalling.scala
+++ b/runtime/src/main/scala/org/apache/pekko/grpc/javadsl/GrpcMarshalling.scala
@@ -114,7 +114,7 @@ object GrpcMarshalling {
       eHandler: JFunction[ActorSystem, JFunction[Throwable, Trailers]]): CompletionStage[HttpResponse] =
     try {
       response match {
-        case future: CompletableFuture[_] if future.isDone =>
+        case future: CompletableFuture[?] if future.isDone =>
           try completedResponse(marshal(completedValue[Out](future), m, writer, system, eHandler))
           catch {
             case NonFatal(error) => handleUnaryFailure(error, writer, system, eHandler)
@@ -157,6 +157,6 @@ object GrpcMarshalling {
       case NonFatal(error) => failure(error)
     }
 
-  private def completedValue[T](future: CompletableFuture[_]): T =
+  private def completedValue[T](future: CompletableFuture[?]): T =
     future.asInstanceOf[CompletableFuture[T]].getNow(null.asInstanceOf[T])
 }

--- a/runtime/src/main/scala/org/apache/pekko/grpc/scaladsl/Grpc.scala
+++ b/runtime/src/main/scala/org/apache/pekko/grpc/scaladsl/Grpc.scala
@@ -63,5 +63,5 @@ private[grpc] final class GrpcImpl(system: ExtendedActorSystem) extends Extensio
 private[grpc] object Grpc extends ExtensionId[GrpcImpl] with ExtensionIdProvider {
   override def createExtension(system: ExtendedActorSystem): GrpcImpl = new GrpcImpl(system)
 
-  override def lookup: ExtensionId[_ <: Extension] = Grpc
+  override def lookup: ExtensionId[? <: Extension] = Grpc
 }

--- a/runtime/src/test/scala/org/apache/pekko/grpc/internal/ChannelUtilsSpec.scala
+++ b/runtime/src/test/scala/org/apache/pekko/grpc/internal/ChannelUtilsSpec.scala
@@ -89,7 +89,7 @@ class ChannelUtilsSpec extends AnyWordSpec with Matchers with ScalaFutures {
       // CONNECTING => FAILURE
       fakeChannel.runCallBack()
       promiseReady.isCompleted shouldEqual true
-      promiseReady.future.value.get shouldBe a[Failure[_]]
+      promiseReady.future.value.get shouldBe a[Failure[?]]
       promiseReady.future.failed.value.get.get.getMessage should startWith("Unable to establish connection")
     }
 
@@ -140,7 +140,7 @@ class ChannelUtilsSpec extends AnyWordSpec with Matchers with ScalaFutures {
       promiseReady.isCompleted shouldEqual true
       promiseDone.isCompleted shouldEqual true
 
-      promiseDone.future.value.get shouldBe a[Failure[_]]
+      promiseDone.future.value.get shouldBe a[Failure[?]]
       promiseDone.future.failed.value.get.get.getMessage should startWith("Unable to establish connection")
     }
 

--- a/runtime/src/test/scala/org/apache/pekko/grpc/internal/PekkoHttpClientUtilsSpec.scala
+++ b/runtime/src/test/scala/org/apache/pekko/grpc/internal/PekkoHttpClientUtilsSpec.scala
@@ -72,7 +72,7 @@ class PekkoHttpClientUtilsSpec extends TestKit(ActorSystem()) with AnyWordSpecLi
         new HttpResponse(
           OK,
           responseHeaders,
-          Map.empty[AttributeKey[_], Any].updated(AttributeKeys.trailer, responseTrailers),
+          Map.empty[AttributeKey[?], Any].updated(AttributeKeys.trailer, responseTrailers),
           Strict(GrpcProtocolNative.contentType, ByteString.empty),
           HttpProtocols.`HTTP/1.1`))
       val source = PekkoHttpClientUtils.responseToSource(response, null)

--- a/sbt-plugin/src/sbt-test/gen-scala-server/00-interop/src/test/scala/org/apache/pekko/grpc/PekkoGrpcClientTester.scala
+++ b/sbt-plugin/src/sbt-test/gen-scala-server/00-interop/src/test/scala/org/apache/pekko/grpc/PekkoGrpcClientTester.scala
@@ -313,12 +313,12 @@ class PekkoGrpcClientTester(val settings: Settings)(implicit system: ActorSystem
     throw new RuntimeException("Not implemented!timeoutOnSleepingServer") with NoStackTrace
   }
 
-  def assertFailure(failure: Future[_], expectedStatus: Status): Unit = {
+  def assertFailure(failure: Future[?], expectedStatus: Status): Unit = {
     val e = Await.result(failure.failed, awaitTimeout).asInstanceOf[StatusRuntimeException]
     assertEquals(expectedStatus.getCode, e.getStatus.getCode)
   }
 
-  def assertFailure(failure: Future[_], expectedStatus: Status, expectedMessage: String): Unit = {
+  def assertFailure(failure: Future[?], expectedStatus: Status, expectedMessage: String): Unit = {
     val e = Await.result(failure.failed, awaitTimeout).asInstanceOf[StatusRuntimeException]
     assertEquals(expectedStatus.getCode, e.getStatus.getCode)
     assertEquals(expectedMessage, e.getStatus.getDescription)

--- a/sbt-plugin/src/sbt-test/gen-scala-server/06-compatibility-plugins/project/ProtocGoPlugin.scala
+++ b/sbt-plugin/src/sbt-test/gen-scala-server/06-compatibility-plugins/project/ProtocGoPlugin.scala
@@ -18,7 +18,7 @@ object ProtocGoPlugin extends AutoPlugin {
 
   override def requires: Plugins = ProtocPlugin
 
-  override def projectSettings: Seq[Def.Setting[_]] =
+  override def projectSettings: Seq[Def.Setting[?]] =
     Seq(Compile, Test).flatMap(inConfig(_)(
       Seq(
         PB.targets += PB.gens.go -> resourceManaged.value / "go")))


### PR DESCRIPTION
### Motivation
Let Scala 3 Community build compile pekko-grpc.

### Modification
Update `.scalafmt.conf` dialect to `scala213source3` and enable Scala 3 syntax rewrite rules (`rewrite.scala3.convertToNewSyntax`), then reformat all sources. Key changes:
- Wildcard type `_` → `?` (e.g. `Class[_]` → `Class[?]`)

### Result
Code is compatible with Scala 3 compiler when built with the community build.

### Tests
Not run - formatting only

### References
Refs apache/pekko#3048