### PR TITLE
build: fix sbt lint warning by excluding previewPath key

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -272,6 +272,7 @@ lazy val docs = Project(id = "docs", base = file("docs"))
     makeSite := makeSite.dependsOn(LocalRootProject / ScalaUnidoc / doc).value,
     pekkoParadoxGithub := Some("https://github.com/apache/pekko-grpc"),
     previewPath := (Paradox / siteSubdirName).value,
+    Global / excludeLintKeys += previewPath,
     Preprocess / siteSubdirName := s"api/pekko-grpc/${projectInfoVersion.value}",
     Preprocess / sourceDirectory := (LocalRootProject / ScalaUnidoc / unidoc / target).value,
     Paradox / siteSubdirName := s"docs/pekko-grpc/${projectInfoVersion.value}",


### PR DESCRIPTION
### Motivation
sbt lint reported unused `docs/previewSite/previewPath` key.

### Modification
Add `Global / excludeLintKeys += previewPath` in `build.sbt` docs project.

### Result
sbt lint warning resolved.

### Tests
- `sbt "clean; compile"` - zero sbt lint warnings

### References
None - build configuration cleanup