### PR TITLE
fix: remove -Yfuture-lazy-vals for Scala 3.9+

### DIFF
--- a/project/Common.scala
+++ b/project/Common.scala
@@ -54,14 +54,8 @@ object Common extends AutoPlugin {
            "-encoding",
            "UTF-8")
        else
-         Seq(
-           "-unchecked",
-           "-deprecation",
-           "-Werror",
-           "-Wunused:imports",
-           "-Yfuture-lazy-vals",
-           "-encoding",
-           "UTF-8")),
+         Seq("-unchecked", "-deprecation", "-Werror", "-Wunused:imports", "-encoding", "UTF-8") ++
+           (if (CrossVersion.partialVersion(scalaVersion.value).exists(_._2 < 9)) Seq("-Yfuture-lazy-vals") else Seq.empty)),
     Compile / scalacOptions ++=
       (if (!isScala3.value)
          Seq(

--- a/project/Common.scala
+++ b/project/Common.scala
@@ -55,7 +55,8 @@ object Common extends AutoPlugin {
            "UTF-8")
        else
          Seq("-unchecked", "-deprecation", "-Werror", "-Wunused:imports", "-encoding", "UTF-8") ++
-           (if (CrossVersion.partialVersion(scalaVersion.value).exists(_._2 < 9)) Seq("-Yfuture-lazy-vals") else Seq.empty)),
+         (if (CrossVersion.partialVersion(scalaVersion.value).exists(_._2 < 9)) Seq("-Yfuture-lazy-vals")
+          else Seq.empty)),
     Compile / scalacOptions ++=
       (if (!isScala3.value)
          Seq(


### PR DESCRIPTION
### Motivation
Scala 3.9.0-RC1 removed the `-Yfuture-lazy-vals` compiler option (the behavior is now the default). Under `-Werror`, the "bad option" warning becomes a compilation error.

### Modification
Conditionally include `-Yfuture-lazy-vals` only for Scala 3.x where minor version < 9, using `CrossVersion.partialVersion` check.

### Result
pekko-grpc codegen module compiles cleanly with Scala 3.9.0-RC1.

### Tests
- `sbt "++3.9.0-RC1!; codegen/compile"` passes

### References
None - Scala 3.9 forward compatibility