### PR TITLE
fix: correct typos in pekko-grpc build and tests

### DIFF
--- a/interop-tests/src/test/scala/org/apache/pekko/grpc/scaladsl/NonBalancingIntegrationSpec.scala
+++ b/interop-tests/src/test/scala/org/apache/pekko/grpc/scaladsl/NonBalancingIntegrationSpec.scala
@@ -87,7 +87,7 @@ class NonBalancingIntegrationSpec(backend: String)
 
       Future.sequence(requestsOnFirstConnection).futureValue
       server1.terminate(5.seconds).futureValue
-      // Give it some time to complete unbind (suspected to cause test flakyness)
+      // Give it some time to complete unbind (suspected to cause test flakiness)
       Thread.sleep(250)
       // And restart
       Http().newServerAt("127.0.0.1", server1.localAddress.getPort).bind(GreeterServiceHandler(service1)).futureValue

--- a/sbt-plugin/src/sbt-test/gen-scala-server/06-compatibility-plugins/build.sbt
+++ b/sbt-plugin/src/sbt-test/gen-scala-server/06-compatibility-plugins/build.sbt
@@ -7,7 +7,7 @@
  * This file is part of the Apache Pekko project, which was derived from Akka.
  */
 
-enablePlugins(ProtocGoPlugin) // enable it first to test possibility of getting overriden
+enablePlugins(ProtocGoPlugin) // enable it first to test possibility of getting overridden
 
 scalaVersion := "2.13.18"
 


### PR DESCRIPTION
### Motivation
Typos found in sbt test config and integration test code.

### Modification
- `overriden`→`overridden` in sbt-plugin test build.sbt
- `flakyness`→`flakiness` in NonBalancingIntegrationSpec.scala

### Result
Cleaner codebase with corrected spelling.

### Tests
Not run - typo fixes only (comments/config)

### References
None - typo cleanup