### PR TITLE
refactor: modernize Java example code with Java 17 records

### DIFF
--- a/plugin-tester-java/src/main/java/example/myapp/statefulhelloworld/GreeterActor.java
+++ b/plugin-tester-java/src/main/java/example/myapp/statefulhelloworld/GreeterActor.java
@@ -19,25 +19,13 @@ import org.apache.pekko.actor.Props;
 // #actor
 public class GreeterActor extends AbstractActor {
 
-  public static class ChangeGreeting {
-    public final String newGreeting;
-
-    public ChangeGreeting(String newGreeting) {
-      this.newGreeting = newGreeting;
-    }
-  }
+  public record ChangeGreeting(String newGreeting) {}
 
   public static class GetGreeting {}
 
   public static GetGreeting GET_GREETING = new GetGreeting();
 
-  public static class Greeting {
-    public final String greeting;
-
-    public Greeting(String greeting) {
-      this.greeting = greeting;
-    }
-  }
+  public record Greeting(String greeting) {}
 
   public static Props props(final String initialGreeting) {
     return Props.create(GreeterActor.class, () -> new GreeterActor(initialGreeting));
@@ -61,7 +49,7 @@ public class GreeterActor extends AbstractActor {
   }
 
   private void onChangeGreeting(ChangeGreeting change) {
-    greeting = new Greeting(change.newGreeting);
+    greeting = new Greeting(change.newGreeting());
   }
 }
 // #actor

--- a/plugin-tester-java/src/main/java/example/myapp/statefulhelloworld/GreeterServiceImpl.java
+++ b/plugin-tester-java/src/main/java/example/myapp/statefulhelloworld/GreeterServiceImpl.java
@@ -38,7 +38,7 @@ public final class GreeterServiceImpl implements GreeterService {
         .thenApply(
             message ->
                 HelloReply.newBuilder()
-                    .setMessage(((GreeterActor.Greeting) message).greeting)
+                    .setMessage(((GreeterActor.Greeting) message).greeting())
                     .build());
   }
 

--- a/plugin-tester-java/src/main/java/example/myapp/typedhelloworld/GreeterActor.java
+++ b/plugin-tester-java/src/main/java/example/myapp/typedhelloworld/GreeterActor.java
@@ -25,29 +25,11 @@ public class GreeterActor extends AbstractBehavior<GreeterActor.GreetingCommand>
 
   public static interface GreetingCommand {}
 
-  public static class ChangeGreeting implements GreetingCommand {
-    public final String newGreeting;
+  public record ChangeGreeting(String newGreeting) implements GreetingCommand {}
 
-    public ChangeGreeting(String newGreeting) {
-      this.newGreeting = newGreeting;
-    }
-  }
+  public record GetGreeting(ActorRef<Greeting> replyTo) implements GreetingCommand {}
 
-  public static class GetGreeting implements GreetingCommand {
-    public final ActorRef<Greeting> replyTo;
-
-    public GetGreeting(ActorRef<Greeting> replyTo) {
-      this.replyTo = replyTo;
-    }
-  }
-
-  public static class Greeting {
-    public final String greeting;
-
-    public Greeting(String greeting) {
-      this.greeting = greeting;
-    }
-  }
+  public record Greeting(String greeting) {}
 
   public static Behavior<GreetingCommand> create(final String initialGreeting) {
     return Behaviors.setup(context -> new GreeterActor(context, initialGreeting));
@@ -67,12 +49,12 @@ public class GreeterActor extends AbstractBehavior<GreeterActor.GreetingCommand>
   }
 
   private Behavior<GreetingCommand> onGetGreeting(GetGreeting get) {
-    get.replyTo.tell(greeting);
+    get.replyTo().tell(greeting);
     return this;
   }
 
   private Behavior<GreetingCommand> onChangeGreeting(ChangeGreeting change) {
-    greeting = new Greeting(change.newGreeting);
+    greeting = new Greeting(change.newGreeting());
     return this;
   }
 }

--- a/plugin-tester-java/src/main/java/example/myapp/typedhelloworld/GreeterServiceImpl.java
+++ b/plugin-tester-java/src/main/java/example/myapp/typedhelloworld/GreeterServiceImpl.java
@@ -42,7 +42,9 @@ public final class GreeterServiceImpl implements GreeterService {
             system.scheduler());
     return response.thenApply(
         message ->
-            HelloReply.newBuilder().setMessage(((GreeterActor.Greeting) message).greeting).build());
+            HelloReply.newBuilder()
+                .setMessage(((GreeterActor.Greeting) message).greeting())
+                .build());
   }
 
   public CompletionStage<ChangeResponse> changeGreeting(ChangeRequest in) {


### PR DESCRIPTION
### Motivation
Java 17 introduced records that make Java code more concise by eliminating boilerplate for data carrier classes.

### Modification
- Convert ChangeGreeting, GetGreeting, Greeting to records in typedhelloworld GreeterActor
- Convert ChangeGreeting, Greeting to records in statefulhelloworld GreeterActor
- Update field accesses to use record accessor methods

### Result
Example Java code is more concise and idiomatic for Java 17+.

### Tests
- `sbt "plugin-tester-java / compile"` (to be verified by CI)

### References
None - code modernization