### PR TITLE
sbt-plugin: publish in non-legacy style

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -170,7 +170,6 @@ lazy val sbtPlugin = Project(id = "sbt-plugin", base = file("sbt-plugin"))
   .settings(Dependencies.sbtPlugin)
   .settings(
     name := s"$pekkoPrefix-sbt-plugin",
-    sbtPluginPublishLegacyMavenStyle := true,
     pluginCrossBuild / sbtVersion := {
       scalaBinaryVersion.value match {
         case "2.12" => "1.12.11"


### PR DESCRIPTION
We enabled the legacy style this in the past (#543) to keep support for sbt 1.8 and below.

Now that `main` targets a future 2.0.0 release, I think it's reasonable to move to the non-legacy style there. Notably the Maven Portal no longer supports the old style, and while _currently_ we're not affected by that as we deploy through `repository.a.o` this seems risky.