### PR TITLE
Update .scala-steward.conf for version pins

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -7,7 +7,7 @@ updates.pin = [
   # Scala 3.3 is a LTS
   { groupId = "org.scala-lang", artifactId = "scala3-library", version = "3.3." }
   # we have too many build plugins that need sbt 1.x
-  { groupId = "org.scala-sbt", artifactId = "sbt"  version = "1." }
+  { groupId = "org.scala-sbt", artifactId = "sbt", version = "1." }
 ]
 
 updatePullRequests = "always"

--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -4,15 +4,10 @@ updates.ignore = [
 ]
 
 updates.pin = [
-
-  # https://github.com/akka/akka-grpc/issues/1506
-  { groupId = "org.eclipse.jgit", artifactId = "org.eclipse.jgit", version = "5." },
-
   # Scala 3.3 is a LTS
   { groupId = "org.scala-lang", artifactId = "scala3-library", version = "3.3." }
-  # when we update to protobuf 4.x we probably need to update a bunch of libraries
-  # in tandem, and possibly schedule this for a major pekko-grpc release
-  { groupId = "com.google.protobuf", version = "3." }
+  # we have too many build plugins that need sbt 1.x
+  { groupId = "org.scala-sbt", artifactId = "sbt"  version = "1." }
 ]
 
 updatePullRequests = "always"


### PR DESCRIPTION
Removed outdated JGit and protobuf version pin and added SBT version pin.

see https://github.com/apache/pekko-connectors/pull/1695