### PR TITLE
consistently include proto's in built artifacts

### DIFF
--- a/sbt-plugin/src/main/scala/org/apache/pekko/grpc/sbt/PekkoGrpcPlugin.scala
+++ b/sbt-plugin/src/main/scala/org/apache/pekko/grpc/sbt/PekkoGrpcPlugin.scala
@@ -117,7 +117,28 @@ object PekkoGrpcPlugin extends AutoPlugin {
         pekkoGrpcCodeGeneratorSettings / target := crossTarget.value / "pekko-grpc" / Defaults.nameForSrc(
           configuration.value.name),
         managedSourceDirectories += (pekkoGrpcCodeGeneratorSettings / target).value,
-        unmanagedResourceDirectories ++= (PB.recompile / resourceDirectories).value,
+        packageBin / mappings := {
+          val existingMappings = (packageBin / mappings).value
+          val unpackedFiles = PB.unpackDependencies.value.files
+          val mappingsToAdd =
+            unpackedFiles.pair(Path.relativeTo(Seq(PB.externalSourcePath.value, PB.externalIncludePath.value)))
+          @scala.annotation.tailrec
+          def withoutDuplicates(soFar: List[(File, String)], seen: Set[String], toAdd: Seq[(File, String)])
+              : Seq[(File, String)] = {
+            toAdd.headOption match {
+              case Some((file, string)) =>
+                if (seen.contains(string)) {
+                  withoutDuplicates(soFar, seen, toAdd.tail)
+                } else {
+                  withoutDuplicates((file, string) :: soFar, seen + string, toAdd.tail)
+                }
+              case None =>
+                soFar
+            }
+          }
+          withoutDuplicates(existingMappings.toList, existingMappings.map(_._2).toSet, mappingsToAdd)
+        },
+        unmanagedResourceDirectories ++= (PB.recompile / unmanagedResourceDirectories).value,
         Defaults.ConfigZero / watchSources ++= Def.uncached {
           (PB.recompile / sources).value.map(f => WatchSource(f))
         },
@@ -135,30 +156,7 @@ object PekkoGrpcPlugin extends AutoPlugin {
             (pekkoGrpcCodeGeneratorSettings / target).value,
             pekkoGrpcCodeGeneratorSettings.value,
             pekkoGrpcGenerators.value),
-        PB.protoSources += sourceDirectory.value / "proto")) ++
-    inConfig(config)(Seq(
-      PB.recompile / includeFilter := GlobFilter("*.proto"),
-      PB.recompile / managedSourceDirectories := Nil,
-      PB.recompile / unmanagedSourceDirectories := Seq(sourceDirectory.value),
-      PB.recompile / sourceDirectories := (PB.recompile / unmanagedSourceDirectories).value ++
-      (PB.recompile / managedSourceDirectories).value,
-      PB.recompile / managedSources := Nil,
-      PB.recompile / unmanagedSources := {
-        Defaults.collectFiles(PB.recompile / unmanagedSourceDirectories, PB.recompile / includeFilter,
-          PB.recompile / excludeFilter).value
-      },
-      PB.recompile / sources := (PB.recompile / managedSources).value ++ (PB.recompile / unmanagedSources).value,
-      PB.recompile / managedResourceDirectories := Nil,
-      PB.recompile / unmanagedResourceDirectories := resourceDirectory.value +: PB.protoSources.value,
-      PB.recompile / resourceDirectories := (PB.recompile / unmanagedResourceDirectories).value ++
-      (PB.recompile / managedResourceDirectories).value,
-      PB.recompile / managedResources := Nil,
-      PB.recompile / unmanagedResources := {
-        Defaults.collectFiles(PB.recompile / unmanagedResourceDirectories, PB.recompile / includeFilter,
-          PB.recompile / excludeFilter).value
-      },
-      PB.recompile / resources := (PB.recompile / managedResources).value ++
-      (PB.recompile / unmanagedResources).value))
+        PB.protoSources += sourceDirectory.value / "proto"))
 
   def targetsFor(
       targetPath: File,

--- a/sbt-plugin/src/sbt-test/gen-scala-server/00-interop/build.sbt
+++ b/sbt-plugin/src/sbt-test/gen-scala-server/00-interop/build.sbt
@@ -73,3 +73,12 @@ pekkoGrpcGeneratedSources := Seq(PekkoGrpc.Client, PekkoGrpc.Server)
 pekkoGrpcGeneratedLanguages := Seq(PekkoGrpc.Scala, PekkoGrpc.Java)
 pekkoGrpcCodeGeneratorSettings := pekkoGrpcCodeGeneratorSettings.value.filterNot(_ == "flat_package")
 //#languages-both
+
+// Make sure proto's reliably make it into the artifact:
+TaskKey[Unit]("checkJar") := {
+  val binary = (Compile / packageBin).value
+  IO.withTemporaryDirectory { dir =>
+    val files = IO.unzip(binary, dir, "*.proto")
+    assert(files.contains(dir / "google/protobuf/duration.proto"))
+  }
+}

--- a/sbt-plugin/src/sbt-test/gen-scala-server/00-interop/test
+++ b/sbt-plugin/src/sbt-test/gen-scala-server/00-interop/test
@@ -1,1 +1,2 @@
+> checkJar
 > test


### PR DESCRIPTION
Fixes #345

I observed the directory with the proto's was part of the `unmanagedResourceDirectories`. That might explain why they weren't included consistently: 'unmanaged' directories are for files that are expected to 'just exist' on disk, to there's no guard to make sure sbt reads that directory after it's been populated. This seemed to be caused by some code added in https://github.com/akka/akka-grpc/pull/149/changes which is intended to cover a fringe use case that probably doesn't really exist anymore, has this problem, and makes things complicated. This PRs simplifies things and makes sure the external proto directory is part of the managed classpath - but testing with `google-cloud-pub-sub-grpc` it seems to actually consistently _not_ include the resources in the jar :laughing: . More detective work needed.

This perhaps begs the question: are we sure we *want* to include the proto's in the artifacts? The generated API's should be fully usable just by the generated code, right?