### PR TITLE
refactor: migrate Arrays.asList to List.of() factory method

### DIFF
--- a/benchmark-java/src/main/java/org/apache/pekko/grpc/benchmarks/qps/ClientConfiguration.java
+++ b/benchmark-java/src/main/java/org/apache/pekko/grpc/benchmarks/qps/ClientConfiguration.java
@@ -31,7 +31,6 @@ import java.util.Set;
 
 import static org.apache.pekko.grpc.benchmarks.Utils.parseBoolean;
 import static java.lang.Integer.parseInt;
-import static java.util.Arrays.asList;
 
 /**
  * Configuration options for benchmark clients.
@@ -119,7 +118,7 @@ public class ClientConfiguration implements Configuration {
         // If no options are supplied, default to including all options.
         supportedParams = ClientParam.values();
       }
-      return Set.copyOf(asList(supportedParams));
+      return Set.of(supportedParams);
     }
   }
 

--- a/benchmark-java/src/main/java/org/apache/pekko/grpc/benchmarks/qps/ServerConfiguration.java
+++ b/benchmark-java/src/main/java/org/apache/pekko/grpc/benchmarks/qps/ServerConfiguration.java
@@ -73,7 +73,7 @@ class ServerConfiguration implements Configuration {
     }
 
     private static List<Param> supportedParams() {
-      return List.copyOf(Arrays.asList(ServerParam.values()));
+      return List.of(ServerParam.values());
     }
   }
 

--- a/interop-tests/src/main/java/org/apache/pekko/grpc/interop/PekkoGrpcServerJava.java
+++ b/interop-tests/src/main/java/org/apache/pekko/grpc/interop/PekkoGrpcServerJava.java
@@ -27,8 +27,8 @@ import java.security.SecureRandom;
 import java.security.cert.Certificate;
 import java.security.cert.CertificateFactory;
 import java.security.spec.PKCS8EncodedKeySpec;
-import java.util.Arrays;
 import java.util.Iterator;
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import javax.net.ssl.KeyManagerFactory;
@@ -88,7 +88,7 @@ public class PekkoGrpcServerJava extends GrpcServer<Tuple2<ActorSystem, ServerBi
     ServerSettings serverSettings = ServerSettings.create(sys);
 
     CompletionStage<ServerBinding> binding;
-    if (Arrays.asList(args).contains("--use_tls=false")) {
+    if (List.of(args).contains("--use_tls=false")) {
       binding =
           Http.get(sys)
               .newServerAt("127.0.0.1", 0)

--- a/plugin-tester-java/src/main/java/example/myapp/CombinedServer.java
+++ b/plugin-tester-java/src/main/java/example/myapp/CombinedServer.java
@@ -20,7 +20,7 @@ import org.apache.pekko.stream.Materializer;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 
-import java.util.Arrays;
+import java.util.List;
 import java.util.concurrent.CompletionStage;
 
 // #import
@@ -68,7 +68,7 @@ class CombinedServer {
 
     // #grpc-web
     Function<HttpRequest, CompletionStage<HttpResponse>> grpcWebServiceHandlers =
-        WebHandler.grpcWebHandler(Arrays.asList(greeterService, echoService), sys, mat);
+        WebHandler.grpcWebHandler(List.of(greeterService, echoService), sys, mat);
 
     Http.get(sys)
         .newServerAt("127.0.0.1", 8090)

--- a/sbt-plugin/src/sbt-test/gen-java/02-server-reflection/src/main/java/example/myapp/helloworld/Main.java
+++ b/sbt-plugin/src/sbt-test/gen-java/02-server-reflection/src/main/java/example/myapp/helloworld/Main.java
@@ -20,7 +20,7 @@ import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 
 //#server-reflection
-import java.util.Arrays;
+import java.util.List;
 
 import org.apache.pekko.grpc.javadsl.ServiceHandler;
 import org.apache.pekko.grpc.javadsl.ServerReflection;
@@ -55,7 +55,7 @@ public class Main {
                 EchoServiceHandlerFactory.create(new EchoServiceImpl(), sys);
         // Create the reflection handler for multiple services
         Function<HttpRequest, CompletionStage<HttpResponse>> reflectionPartial =
-                ServerReflection.create(Arrays.asList(GreeterService.description, EchoService.description), sys);
+                ServerReflection.create(List.of(GreeterService.description, EchoService.description), sys);
 
         // Concatenate the partial functions into a single handler
         ServiceHandler.concatOrNotFound(


### PR DESCRIPTION
### Motivation
Java 9+ `List.of()` provides concise, immutable collection creation.

### Modification
Replace `Arrays.asList()` with `List.of()` across 5 files. Update imports.

### Result
Cleaner code using Java 17 immutable collection factories.

### Tests
Not run - compile-only test file changes

### References
None - Java 17 API modernization