### PR TITLE
refactor: replace .collect(Collectors.toList()) with .toList()

### DIFF
--- a/plugin-tester-java/src/main/java/example/myapp/helloworld/GreeterClient.java
+++ b/plugin-tester-java/src/main/java/example/myapp/helloworld/GreeterClient.java
@@ -20,7 +20,6 @@ import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.pekko.Done;
 import org.apache.pekko.NotUsed;
@@ -72,7 +71,7 @@ class GreeterClient {
     List<HelloRequest> requests =
         Stream.of("Alice", "Bob", "Peter")
             .map(name -> HelloRequest.newBuilder().setName(name).build())
-            .collect(Collectors.toList());
+            .toList();
     CompletionStage<HelloReply> reply = client.itKeepsTalking(Source.from(requests));
     System.out.println(
         "got single reply for streaming requests: "

--- a/plugin-tester-java/src/main/java/example/myapp/helloworld/GreeterServiceImpl.java
+++ b/plugin-tester-java/src/main/java/example/myapp/helloworld/GreeterServiceImpl.java
@@ -48,11 +48,7 @@ public class GreeterServiceImpl implements GreeterService {
     return in.runWith(Sink.<HelloRequest>seq(), mat)
         .thenApply(
             elements -> {
-              String elementsStr =
-                  elements.stream()
-                      .map(HelloRequest::getName)
-                      .toList()
-                      .toString();
+              String elementsStr = elements.stream().map(HelloRequest::getName).toList().toString();
               return HelloReply.newBuilder().setMessage("Hello, " + elementsStr).build();
             });
   }

--- a/plugin-tester-java/src/main/java/example/myapp/helloworld/GreeterServiceImpl.java
+++ b/plugin-tester-java/src/main/java/example/myapp/helloworld/GreeterServiceImpl.java
@@ -19,7 +19,6 @@ import example.myapp.helloworld.grpc.*;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
-import java.util.stream.Collectors;
 import org.apache.pekko.NotUsed;
 import org.apache.pekko.stream.Materializer;
 import org.apache.pekko.stream.javadsl.Sink;
@@ -52,7 +51,7 @@ public class GreeterServiceImpl implements GreeterService {
               String elementsStr =
                   elements.stream()
                       .map(HelloRequest::getName)
-                      .collect(Collectors.toList())
+                      .toList()
                       .toString();
               return HelloReply.newBuilder().setMessage("Hello, " + elementsStr).build();
             });
@@ -62,7 +61,7 @@ public class GreeterServiceImpl implements GreeterService {
   public Source<HelloReply, NotUsed> itKeepsReplying(HelloRequest in) {
     System.out.println("sayHello to " + in.getName() + " with stream of chars");
     List<Character> characters =
-        ("Hello, " + in.getName()).chars().mapToObj(c -> (char) c).collect(Collectors.toList());
+        ("Hello, " + in.getName()).chars().mapToObj(c -> (char) c).toList();
     return Source.from(characters)
         .map(character -> HelloReply.newBuilder().setMessage(String.valueOf(character)).build());
   }

--- a/plugin-tester-java/src/main/java/example/myapp/helloworld/LiftedGreeterClient.java
+++ b/plugin-tester-java/src/main/java/example/myapp/helloworld/LiftedGreeterClient.java
@@ -19,7 +19,6 @@ import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.pekko.Done;
 import org.apache.pekko.NotUsed;
@@ -68,7 +67,7 @@ class LiftedGreeterClient {
     List<HelloRequest> requests =
         Stream.of("Alice", "Bob", "Peter")
             .map(name -> HelloRequest.newBuilder().setName(name).build())
-            .collect(Collectors.toList());
+            .toList();
     CompletionStage<HelloReply> reply =
         client.itKeepsTalking().addHeader("key", "value").invoke(Source.from(requests));
     System.out.println(

--- a/plugin-tester-java/src/main/java/example/myapp/helloworld/PowerGreeterServiceImpl.java
+++ b/plugin-tester-java/src/main/java/example/myapp/helloworld/PowerGreeterServiceImpl.java
@@ -20,7 +20,6 @@ import example.myapp.helloworld.grpc.HelloRequest;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
-import java.util.stream.Collectors;
 import org.apache.pekko.NotUsed;
 import org.apache.pekko.grpc.javadsl.Metadata;
 import org.apache.pekko.stream.Materializer;
@@ -52,7 +51,7 @@ public class PowerGreeterServiceImpl implements GreeterServicePowerApi {
               String elementsStr =
                   elements.stream()
                       .map(elem -> authTaggedName(elem, metadata))
-                      .collect(Collectors.toList())
+                      .toList()
                       .toString();
               return HelloReply.newBuilder().setMessage("Hello, " + elementsStr).build();
             });
@@ -63,7 +62,7 @@ public class PowerGreeterServiceImpl implements GreeterServicePowerApi {
     String greetee = authTaggedName(in, metadata);
     System.out.println("sayHello to " + greetee + " with stream of chars");
     List<Character> characters =
-        ("Hello, " + greetee).chars().mapToObj(c -> (char) c).collect(Collectors.toList());
+        ("Hello, " + greetee).chars().mapToObj(c -> (char) c).toList();
     return Source.from(characters)
         .map(character -> HelloReply.newBuilder().setMessage(String.valueOf(character)).build());
   }

--- a/plugin-tester-java/src/main/java/example/myapp/helloworld/PowerGreeterServiceImpl.java
+++ b/plugin-tester-java/src/main/java/example/myapp/helloworld/PowerGreeterServiceImpl.java
@@ -49,10 +49,7 @@ public class PowerGreeterServiceImpl implements GreeterServicePowerApi {
         .thenApply(
             elements -> {
               String elementsStr =
-                  elements.stream()
-                      .map(elem -> authTaggedName(elem, metadata))
-                      .toList()
-                      .toString();
+                  elements.stream().map(elem -> authTaggedName(elem, metadata)).toList().toString();
               return HelloReply.newBuilder().setMessage("Hello, " + elementsStr).build();
             });
   }
@@ -61,8 +58,7 @@ public class PowerGreeterServiceImpl implements GreeterServicePowerApi {
   public Source<HelloReply, NotUsed> itKeepsReplying(HelloRequest in, Metadata metadata) {
     String greetee = authTaggedName(in, metadata);
     System.out.println("sayHello to " + greetee + " with stream of chars");
-    List<Character> characters =
-        ("Hello, " + greetee).chars().mapToObj(c -> (char) c).toList();
+    List<Character> characters = ("Hello, " + greetee).chars().mapToObj(c -> (char) c).toList();
     return Source.from(characters)
         .map(character -> HelloReply.newBuilder().setMessage(String.valueOf(character)).build());
   }


### PR DESCRIPTION
### Motivation
Java 16+ `Stream.toList()` provides a concise way to collect stream elements into an unmodifiable list.

### Modification
Replace `.collect(Collectors.toList())` with `.toList()` across 4 files. Remove unused `Collectors` imports.

### Result
Cleaner stream collection code using Java 17 API.

### Tests
Not run - compile-only test file changes

### References
None - Java 17 API modernization