### PR TITLE
refactor: migrate String.format to String.formatted (Java 15+)

### DIFF
--- a/plugin-tester-java/src/main/java/example/myapp/helloworld/PowerGreeterServiceImpl.java
+++ b/plugin-tester-java/src/main/java/example/myapp/helloworld/PowerGreeterServiceImpl.java
@@ -85,8 +85,7 @@ public class PowerGreeterServiceImpl implements GreeterServicePowerApi {
   }
 
   private String authTaggedName(HelloRequest in, Metadata metadata) {
-    return String.format(
-        "%s (%sauthenticated)", in.getName(), isAuthenticated(metadata) ? "" : "not ");
+    return "%s (%sauthenticated)".formatted(in.getName(), isAuthenticated(metadata) ? "" : "not ");
   }
 }
 // #full-service-impl


### PR DESCRIPTION
## Summary
- Migrate `String.format("literal", args)` to `"literal".formatted(args)` (Java 15+ API)
- 1 file updated: gRPC PowerGreeter service implementation
- Behavior-preserving refactoring, no functional changes

## Test plan
- [ ] Existing tests pass (behavior-preserving refactoring)
- [ ] `sbt javafmtAll` passes with JDK 17