### PR TITLE
refactor: migrate switch statements to modern switch syntax (Java 14+)

### DIFF
--- a/benchmark-java/src/main/java/org/apache/pekko/grpc/benchmarks/driver/LoadClient.java
+++ b/benchmark-java/src/main/java/org/apache/pekko/grpc/benchmarks/driver/LoadClient.java
@@ -105,35 +105,30 @@ class LoadClient {
     system.getWhenTerminated().whenComplete((__, t) -> shutdownNow());
 
     // Create the load distribution
-    switch (config.getLoadParams().getLoadCase()) {
-      case CLOSED_LOOP:
-        distribution = null;
-        break;
-      case LOAD_NOT_SET:
-        distribution = null;
-        break;
-      case POISSON:
-        // Mean of exp distribution per thread is <no threads> / <offered load per second>
-        distribution = new ExponentialDistribution(
-            threadCount / config.getLoadParams().getPoisson().getOfferedLoad());
-        break;
-      default:
-        throw new IllegalArgumentException("Scenario not implemented");
-    }
+    distribution =
+        switch (config.getLoadParams().getLoadCase()) {
+          case CLOSED_LOOP, LOAD_NOT_SET -> null;
+          case POISSON ->
+          // Mean of exp distribution per thread is <no threads> / <offered load per second>
+          new ExponentialDistribution(
+              threadCount / config.getLoadParams().getPoisson().getOfferedLoad());
+          default -> throw new IllegalArgumentException("Scenario not implemented");
+        };
 
     // Create payloads
-    switch (config.getPayloadConfig().getPayloadCase()) {
-      case SIMPLE_PARAMS: {
-        Payloads.SimpleProtoParams simpleParams = config.getPayloadConfig().getSimpleParams();
-        simpleRequest = Utils.makeRequest(Messages.PayloadType.COMPRESSABLE,
-            simpleParams.getReqSize(), simpleParams.getRespSize());
-        break;
-      }
-      default: {
-        // Not implemented yet
-        throw new IllegalArgumentException("Scenario not implemented");
-      }
-    }
+    simpleRequest =
+        switch (config.getPayloadConfig().getPayloadCase()) {
+          case SIMPLE_PARAMS -> {
+            Payloads.SimpleProtoParams simpleParams = config.getPayloadConfig().getSimpleParams();
+            yield Utils.makeRequest(
+                Messages.PayloadType.COMPRESSABLE,
+                simpleParams.getReqSize(),
+                simpleParams.getRespSize());
+          }
+          default ->
+          // Not implemented yet
+          throw new IllegalArgumentException("Scenario not implemented");
+        };
 
     List<OperatingSystemMXBean> beans =
         ManagementFactory.getPlatformMXBeans(OperatingSystemMXBean.class);
@@ -152,24 +147,24 @@ class LoadClient {
    */
   void start() {
     for (int i = 0; i < threadCount; i++) {
-      Runnable r = null;
-      switch (config.getPayloadConfig().getPayloadCase()) {
-        case SIMPLE_PARAMS: {
-          if (config.getClientType() == Control.ClientType.ASYNC_CLIENT) {
-            if (config.getRpcType() == Control.RpcType.UNARY) {
-              r = new AsyncUnaryWorker(clients[i % clients.length]);
-            } else if (config.getRpcType() == Control.RpcType.STREAMING) {
-              r = new AsyncPingPongWorker(mat, clients[i % clients.length]);
+      Runnable r =
+          switch (config.getPayloadConfig().getPayloadCase()) {
+            case SIMPLE_PARAMS -> {
+              if (config.getClientType() == Control.ClientType.ASYNC_CLIENT) {
+                if (config.getRpcType() == Control.RpcType.UNARY) {
+                  yield new AsyncUnaryWorker(clients[i % clients.length]);
+                } else if (config.getRpcType() == Control.RpcType.STREAMING) {
+                  yield new AsyncPingPongWorker(mat, clients[i % clients.length]);
+                }
+              }
+              yield null;
             }
-          }
-          break;
-        }
-        default: {
-          throw Status.UNIMPLEMENTED.withDescription(
-              "Unknown payload case " + config.getPayloadConfig().getPayloadCase().name())
-              .asRuntimeException();
-        }
-      }
+            default ->
+                throw Status.UNIMPLEMENTED.withDescription(
+                        "Unknown payload case "
+                            + config.getPayloadConfig().getPayloadCase().name())
+                    .asRuntimeException();
+          };
       if (r == null) {
         throw new IllegalStateException(config.getRpcType().name()
             + " not supported for client type "

--- a/benchmark-java/src/main/java/org/apache/pekko/grpc/benchmarks/driver/LoadServer.java
+++ b/benchmark-java/src/main/java/org/apache/pekko/grpc/benchmarks/driver/LoadServer.java
@@ -47,18 +47,11 @@ final class LoadServer {
     port = config.getPort() ==  0 ? Utils.pickUnusedPort() : config.getPort();
 
     switch (config.getServerType()) {
-      case ASYNC_SERVER: {
-        break;
-      }
-      case SYNC_SERVER: {
-        throw new IllegalArgumentException("SYNC_SERVER not implemented");
-      }
-      case ASYNC_GENERIC_SERVER: {
-        throw new IllegalArgumentException("ASYNC_GENERIC_SERVER not implemented");
-      }
-      default: {
-        throw new IllegalArgumentException();
-      }
+      case ASYNC_SERVER -> {}
+      case SYNC_SERVER -> throw new IllegalArgumentException("SYNC_SERVER not implemented");
+      case ASYNC_GENERIC_SERVER ->
+          throw new IllegalArgumentException("ASYNC_GENERIC_SERVER not implemented");
+      default -> throw new IllegalArgumentException();
     }
     if (config.hasSecurityParams()) {
       // FIXME currently only Utils.serverHttpContext and the test certs are used

--- a/benchmark-java/src/main/java/org/apache/pekko/grpc/benchmarks/qps/AsyncClient.java
+++ b/benchmark-java/src/main/java/org/apache/pekko/grpc/benchmarks/qps/AsyncClient.java
@@ -147,14 +147,11 @@ public class AsyncClient {
   }
 
   private Future<Histogram> doRpcs(BenchmarkServiceClient client, SimpleRequest request, long endTime) {
-    switch (config.rpcType) {
-      case UNARY:
-        return doUnaryCalls(client, request, endTime);
-      case STREAMING:
-        return doStreamingCalls(client, request, endTime);
-      default:
-        throw new IllegalStateException("unsupported rpc type");
-    }
+    return switch (config.rpcType) {
+      case UNARY -> doUnaryCalls(client, request, endTime);
+      case STREAMING -> doStreamingCalls(client, request, endTime);
+      default -> throw new IllegalStateException("unsupported rpc type");
+    };
   }
 
   private Future<Histogram> doUnaryCalls(BenchmarkServiceClient client, final SimpleRequest request,

--- a/interop-tests/src/main/java/io/grpc/testing/integration2/TestServiceClient.java
+++ b/interop-tests/src/main/java/io/grpc/testing/integration2/TestServiceClient.java
@@ -111,8 +111,9 @@ public class TestServiceClient {
       case SERVER_COMPRESSED_STREAMING -> clientTester.serverCompressedStreaming();
       case PING_PONG -> clientTester.pingPong();
       case EMPTY_STREAM -> clientTester.emptyStream();
-      case COMPUTE_ENGINE_CREDS -> clientTester.computeEngineCreds(
-          settings.getDefaultServiceAccount(), settings.getOauthScope());
+      case COMPUTE_ENGINE_CREDS ->
+          clientTester.computeEngineCreds(
+              settings.getDefaultServiceAccount(), settings.getOauthScope());
       case SERVICE_ACCOUNT_CREDS -> {
         String jsonKey =
             Files.asCharSource(new File(settings.getServiceAccountKeyFile()), UTF_8).read();

--- a/interop-tests/src/main/java/io/grpc/testing/integration2/TestServiceClient.java
+++ b/interop-tests/src/main/java/io/grpc/testing/integration2/TestServiceClient.java
@@ -100,139 +100,53 @@ public class TestServiceClient {
 
   private void runTest(TestCases testCase, Settings settings) throws Exception {
     switch (testCase) {
-      case EMPTY_UNARY:
-        clientTester.emptyUnary();
-        break;
-
-      case CACHEABLE_UNARY:
-        {
-          clientTester.cacheableUnary();
-          break;
-        }
-
-      case LARGE_UNARY:
-        clientTester.largeUnary();
-        break;
-
-      case CLIENT_COMPRESSED_UNARY:
-        clientTester.clientCompressedUnary(false);
-        break;
-
-      case SERVER_COMPRESSED_UNARY:
-        clientTester.serverCompressedUnary();
-        break;
-
-      case CLIENT_STREAMING:
-        clientTester.clientStreaming();
-        break;
-
-      case CLIENT_COMPRESSED_STREAMING:
-        clientTester.clientCompressedStreaming(false);
-        break;
-
-      case SERVER_STREAMING:
-        clientTester.serverStreaming();
-        break;
-
-      case SERVER_COMPRESSED_STREAMING:
-        clientTester.serverCompressedStreaming();
-        break;
-
-      case PING_PONG:
-        clientTester.pingPong();
-        break;
-
-      case EMPTY_STREAM:
-        clientTester.emptyStream();
-        break;
-
-      case COMPUTE_ENGINE_CREDS:
-        clientTester.computeEngineCreds(
-            settings.getDefaultServiceAccount(), settings.getOauthScope());
-        break;
-
-      case SERVICE_ACCOUNT_CREDS:
-        {
-          String jsonKey =
-              Files.asCharSource(new File(settings.getServiceAccountKeyFile()), UTF_8).read();
-          FileInputStream credentialsStream =
-              new FileInputStream(settings.getServiceAccountKeyFile());
-          clientTester.serviceAccountCreds(jsonKey, credentialsStream, settings.getOauthScope());
-          break;
-        }
-
-      case JWT_TOKEN_CREDS:
-        {
-          FileInputStream credentialsStream =
-              new FileInputStream(settings.getServiceAccountKeyFile());
-          clientTester.jwtTokenCreds(credentialsStream);
-          break;
-        }
-
-      case OAUTH2_AUTH_TOKEN:
-        {
-          String jsonKey =
-              Files.asCharSource(new File(settings.getServiceAccountKeyFile()), UTF_8).read();
-          FileInputStream credentialsStream =
-              new FileInputStream(settings.getServiceAccountKeyFile());
-          clientTester.oauth2AuthToken(jsonKey, credentialsStream, settings.getOauthScope());
-          break;
-        }
-
-      case PER_RPC_CREDS:
-        {
-          String jsonKey =
-              Files.asCharSource(new File(settings.getServiceAccountKeyFile()), UTF_8).read();
-          FileInputStream credentialsStream =
-              new FileInputStream(settings.getServiceAccountKeyFile());
-          clientTester.perRpcCreds(jsonKey, credentialsStream, settings.getOauthScope());
-          break;
-        }
-
-      case CUSTOM_METADATA:
-        {
-          clientTester.customMetadata();
-          break;
-        }
-
-      case STATUS_CODE_AND_MESSAGE:
-        {
-          clientTester.statusCodeAndMessage();
-          break;
-        }
-
-      case UNIMPLEMENTED_METHOD:
-        {
-          clientTester.unimplementedMethod();
-          break;
-        }
-
-      case UNIMPLEMENTED_SERVICE:
-        {
-          clientTester.unimplementedService();
-          break;
-        }
-
-      case CANCEL_AFTER_BEGIN:
-        {
-          clientTester.cancelAfterBegin();
-          break;
-        }
-
-      case CANCEL_AFTER_FIRST_RESPONSE:
-        {
-          clientTester.cancelAfterFirstResponse();
-          break;
-        }
-
-      case TIMEOUT_ON_SLEEPING_SERVER:
-        {
-          clientTester.timeoutOnSleepingServer();
-          break;
-        }
-
-      default:
-        throw new IllegalArgumentException("Unknown test case: " + testCase);
+      case EMPTY_UNARY -> clientTester.emptyUnary();
+      case CACHEABLE_UNARY -> clientTester.cacheableUnary();
+      case LARGE_UNARY -> clientTester.largeUnary();
+      case CLIENT_COMPRESSED_UNARY -> clientTester.clientCompressedUnary(false);
+      case SERVER_COMPRESSED_UNARY -> clientTester.serverCompressedUnary();
+      case CLIENT_STREAMING -> clientTester.clientStreaming();
+      case CLIENT_COMPRESSED_STREAMING -> clientTester.clientCompressedStreaming(false);
+      case SERVER_STREAMING -> clientTester.serverStreaming();
+      case SERVER_COMPRESSED_STREAMING -> clientTester.serverCompressedStreaming();
+      case PING_PONG -> clientTester.pingPong();
+      case EMPTY_STREAM -> clientTester.emptyStream();
+      case COMPUTE_ENGINE_CREDS -> clientTester.computeEngineCreds(
+          settings.getDefaultServiceAccount(), settings.getOauthScope());
+      case SERVICE_ACCOUNT_CREDS -> {
+        String jsonKey =
+            Files.asCharSource(new File(settings.getServiceAccountKeyFile()), UTF_8).read();
+        FileInputStream credentialsStream =
+            new FileInputStream(settings.getServiceAccountKeyFile());
+        clientTester.serviceAccountCreds(jsonKey, credentialsStream, settings.getOauthScope());
+      }
+      case JWT_TOKEN_CREDS -> {
+        FileInputStream credentialsStream =
+            new FileInputStream(settings.getServiceAccountKeyFile());
+        clientTester.jwtTokenCreds(credentialsStream);
+      }
+      case OAUTH2_AUTH_TOKEN -> {
+        String jsonKey =
+            Files.asCharSource(new File(settings.getServiceAccountKeyFile()), UTF_8).read();
+        FileInputStream credentialsStream =
+            new FileInputStream(settings.getServiceAccountKeyFile());
+        clientTester.oauth2AuthToken(jsonKey, credentialsStream, settings.getOauthScope());
+      }
+      case PER_RPC_CREDS -> {
+        String jsonKey =
+            Files.asCharSource(new File(settings.getServiceAccountKeyFile()), UTF_8).read();
+        FileInputStream credentialsStream =
+            new FileInputStream(settings.getServiceAccountKeyFile());
+        clientTester.perRpcCreds(jsonKey, credentialsStream, settings.getOauthScope());
+      }
+      case CUSTOM_METADATA -> clientTester.customMetadata();
+      case STATUS_CODE_AND_MESSAGE -> clientTester.statusCodeAndMessage();
+      case UNIMPLEMENTED_METHOD -> clientTester.unimplementedMethod();
+      case UNIMPLEMENTED_SERVICE -> clientTester.unimplementedService();
+      case CANCEL_AFTER_BEGIN -> clientTester.cancelAfterBegin();
+      case CANCEL_AFTER_FIRST_RESPONSE -> clientTester.cancelAfterFirstResponse();
+      case TIMEOUT_ON_SLEEPING_SERVER -> clientTester.timeoutOnSleepingServer();
+      default -> throw new IllegalArgumentException("Unknown test case: " + testCase);
     }
   }
 }


### PR DESCRIPTION
## Summary
- Migrate switch statements to enhanced switch syntax and switch expressions (Java 14+ API)
- 4 files updated: LoadClient (3 switch expressions), LoadServer (enhanced switch), AsyncClient (switch expression), TestServiceClient (enhanced switch with 22 cases)
- Behavior-preserving refactoring, significant reduction in boilerplate (197 deletions, 96 insertions)

## Test plan
- [ ] Existing tests pass (behavior-preserving refactoring)
- [ ] `sbt javafmtAll` passes with JDK 17