### PR TITLE
refactor: use Files.readString (Java 11+)

### DIFF
--- a/benchmark-java/src/main/java/org/apache/pekko/grpc/benchmarks/Utils.java
+++ b/benchmark-java/src/main/java/org/apache/pekko/grpc/benchmarks/Utils.java
@@ -37,6 +37,7 @@ import java.io.*;
 import java.net.InetSocketAddress;
 import java.net.ServerSocket;
 import java.net.SocketAddress;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.security.KeyFactory;
@@ -156,7 +157,7 @@ public final class Utils {
   }
 
   public static HttpsConnectionContext serverHttpContext() throws Exception {
-    String keyEncoded = new String(Files.readAllBytes(Paths.get(TestUtils.loadCert("server1.key").getAbsolutePath())), "UTF-8")
+    String keyEncoded = Files.readString(Paths.get(TestUtils.loadCert("server1.key").getAbsolutePath()), StandardCharsets.UTF_8)
         .replace("-----BEGIN PRIVATE KEY-----\n", "")
         .replace("-----END PRIVATE KEY-----\n", "")
         .replace("\n", "");

--- a/interop-tests/src/main/java/org/apache/pekko/grpc/interop/PekkoGrpcServerJava.java
+++ b/interop-tests/src/main/java/org/apache/pekko/grpc/interop/PekkoGrpcServerJava.java
@@ -123,7 +123,9 @@ public class PekkoGrpcServerJava extends GrpcServer<Tuple2<ActorSystem, ServerBi
 
   private HttpsConnectionContext serverHttpContext() throws Exception {
     String keyEncoded =
-        Files.readString(Paths.get(TestUtils.loadCert("server1.key").getAbsolutePath()), StandardCharsets.UTF_8)
+        Files.readString(
+                Paths.get(TestUtils.loadCert("server1.key").getAbsolutePath()),
+                StandardCharsets.UTF_8)
             .replace("-----BEGIN PRIVATE KEY-----\n", "")
             .replace("-----END PRIVATE KEY-----\n", "")
             .replace("\n", "");

--- a/interop-tests/src/main/java/org/apache/pekko/grpc/interop/PekkoGrpcServerJava.java
+++ b/interop-tests/src/main/java/org/apache/pekko/grpc/interop/PekkoGrpcServerJava.java
@@ -18,6 +18,7 @@ import io.grpc.internal.testing.TestUtils;
 import io.grpc.testing.integration.TestService;
 import java.io.FileInputStream;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.security.KeyFactory;
@@ -122,9 +123,7 @@ public class PekkoGrpcServerJava extends GrpcServer<Tuple2<ActorSystem, ServerBi
 
   private HttpsConnectionContext serverHttpContext() throws Exception {
     String keyEncoded =
-        new String(
-                Files.readAllBytes(Paths.get(TestUtils.loadCert("server1.key").getAbsolutePath())),
-                "UTF-8")
+        Files.readString(Paths.get(TestUtils.loadCert("server1.key").getAbsolutePath()), StandardCharsets.UTF_8)
             .replace("-----BEGIN PRIVATE KEY-----\n", "")
             .replace("-----END PRIVATE KEY-----\n", "")
             .replace("\n", "");


### PR DESCRIPTION
### Motivation
`Files.readString` was introduced in Java 11 and provides a cleaner API for reading an entire file into a `String`, replacing the `new String(Files.readAllBytes(path), charset)` pattern.

### Modification
Replace `new String(Files.readAllBytes(path), "UTF-8")` with `Files.readString(path, StandardCharsets.UTF_8)` in:
- `benchmark-java/src/main/java/org/apache/pekko/grpc/benchmarks/Utils.java`
- `interop-tests/src/main/java/org/apache/pekko/grpc/interop/PekkoGrpcServerJava.java`

### Result
More idiomatic Java 11+ code with identical behavior.

### Tests
- [ ] Existing tests pass (behavior-preserving refactoring)
- [ ] `sbt javafmtAll` passes with JDK 17

### References
None - Java 11+ API migration