### PR TITLE
chore: document Scala 2.13/3 syntax compatibility requirements in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,6 +9,7 @@ Before opening or updating a PR, verify:
 - Gradle plugin changes pass the Gradle test suite.
 - Maven plugin changes pass Maven integration tests.
 - Native `scalafmt` or the sbt scalafmt tasks were run for changed Scala/SBT files, or the missing tool is recorded in `Tests`.
+- Code must use syntax compatible with both Scala 2.13 and Scala 3. Do not use Scala 3-only syntax such as significant indentation, `as` for import rename, `*` for wildcard import, or postfix `*` for vararg splices. The `.scalafmt.conf` enforces these restrictions via `dialectOverride`.
 - `sbt javafmtAll` was run with JDK 17 when relevant.
 - `sbt headerCreateAll` was run to add headers for new files. Never hand-write or invent license headers; let sbt manage them, and preserve existing copyright notices intact.
 - For copied code, the source file or external project is noted in the PR (see Licensing Rules in `AGENTS.md`).


### PR DESCRIPTION
### Motivation
Document the Scala 2.13 and Scala 3 syntax compatibility requirements in CLAUDE.md to ensure consistent code style.

### Modification
- Add CLAUDE.md rule: code must use syntax compatible with both Scala 2.13 and Scala 3
- Do not use Scala 3-only syntax: significant indentation, `as` for import rename, `*` for wildcard import, postfix `*` for vararg splices
- The `.scalafmt.conf` `dialectOverride` already enforces these restrictions

### Result
CLAUDE.md now explicitly documents the Scala 2.13/3 syntax compatibility requirement, matching the existing `.scalafmt.conf` configuration.

### Tests
Not run - documentation only

### References
None - code style configuration