### PR TITLE
Remove private[this] from Maven plugin

### DIFF
--- a/maven-plugin/src/main/scala/org/apache/pekko/grpc/maven/AbstractGenerateMojo.scala
+++ b/maven-plugin/src/main/scala/org/apache/pekko/grpc/maven/AbstractGenerateMojo.scala
@@ -215,7 +215,7 @@ abstract class AbstractGenerateMojo @Inject() (buildContext: BuildContext) exten
     }
   }
 
-  private[this] def executeProtoc(
+  private def executeProtoc(
       protocCommand: Seq[String] => Int,
       schemas: Set[File],
       protoDir: File,
@@ -235,7 +235,7 @@ abstract class AbstractGenerateMojo @Inject() (buildContext: BuildContext) exten
         throw new RuntimeException("error occurred while compiling protobuf files: %s".format(e.getMessage), e)
     }
 
-  private[this] def compile(
+  private def compile(
       protocCommand: Seq[String] => Int,
       schemas: Set[File],
       protoDir: File,


### PR DESCRIPTION
### Motivation
Avoid `private[this]` in Scala sources.

### Modification
Replace the remaining Maven plugin `private[this]` method modifiers with ordinary `private` modifiers.

### Result
The repository no longer contains `private[this]` usages.

### Tests
- `rg -n "private\\[this\\]" .` / no matches
- `scalafmt --mode diff-ref=origin/main` / passed
- `scalafmt --list --mode diff-ref=origin/main` / passed
- `sbt "maven-plugin / Compile / compile"` / passed
- `git diff --check` / passed

### References
None - cleanup requested separately from #766