### PR TITLE
fix: fix javadoc warning in JavaTestServiceImpl.java

### DIFF
--- a/benchmark-java/src/main/java/org/apache/pekko/grpc/benchmarks/Transport.java
+++ b/benchmark-java/src/main/java/org/apache/pekko/grpc/benchmarks/Transport.java
@@ -39,7 +39,7 @@ public enum Transport {
   /**
    * Validates the given address for this transport.
    *
-   * @throws IllegalArgumentException if the given address is invalid for this transport.
+   * @throws java.lang.IllegalArgumentException if the given address is invalid for this transport.
    */
   public void validateSocketAddress(SocketAddress address) {
     if (!socketAddressValidator.isValidSocketAddress(address)) {

--- a/benchmark-java/src/main/java/org/apache/pekko/grpc/benchmarks/qps/Configuration.java
+++ b/benchmark-java/src/main/java/org/apache/pekko/grpc/benchmarks/qps/Configuration.java
@@ -28,7 +28,7 @@ public interface Configuration {
   interface Builder<T extends Configuration> {
     /**
      * Builds the {@link Configuration} from the given command-line arguments.
-     * @throws IllegalArgumentException if unable to build the configuration for any reason.
+     * @throws java.lang.IllegalArgumentException if unable to build the configuration for any reason.
      */
     T build(String[] args);
 

--- a/benchmark-java/src/main/java/org/apache/pekko/grpc/benchmarks/qps/ServerConfiguration.java
+++ b/benchmark-java/src/main/java/org/apache/pekko/grpc/benchmarks/qps/ServerConfiguration.java
@@ -97,7 +97,7 @@ class ServerConfiguration implements Configuration {
     /**
      * Validates the given address for this transport.
      *
-     * @throws IllegalArgumentException if the given address is invalid for this transport.
+     * @throws java.lang.IllegalArgumentException if the given address is invalid for this transport.
      */
     void validateSocketAddress(SocketAddress address) {
       if (!socketAddressValidator.isValidSocketAddress(address)) {

--- a/interop-tests/src/test/java/org/apache/pekko/grpc/interop/JavaTestServiceImpl.java
+++ b/interop-tests/src/test/java/org/apache/pekko/grpc/interop/JavaTestServiceImpl.java
@@ -32,7 +32,7 @@ import io.grpc.testing.integration.TestService;
 /**
  * Implementation of the generated service.
  *
- * <p>Essentially porting the client code from [[io.grpc.testing.integration.TestServiceImpl]]
+ * <p>Essentially porting the client code from {@code io.grpc.testing.integration.TestServiceImpl}
  * against our API's
  *
  * <p>The same implementation is also be found as part of the 'scripted' tests at

--- a/interop-tests/src/test/java/org/apache/pekko/grpc/interop/PekkoGrpcJavaClientTester.java
+++ b/interop-tests/src/test/java/org/apache/pekko/grpc/interop/PekkoGrpcJavaClientTester.java
@@ -55,7 +55,7 @@ import scala.concurrent.ExecutionContext;
  * ClientTester implementation that uses the generated pekko-grpc Java client to exercise a server
  * under test.
  *
- * <p>Essentially porting the client code from [[io.grpc.testing.integration.AbstractInteropTest]]
+ * <p>Essentially porting the client code from {@code io.grpc.testing.integration.AbstractInteropTest}
  * against our Scala API's
  */
 public class PekkoGrpcJavaClientTester implements ClientTester {

--- a/interop-tests/src/test/java/org/apache/pekko/grpc/interop/PekkoGrpcJavaClientTester.java
+++ b/interop-tests/src/test/java/org/apache/pekko/grpc/interop/PekkoGrpcJavaClientTester.java
@@ -55,8 +55,8 @@ import scala.concurrent.ExecutionContext;
  * ClientTester implementation that uses the generated pekko-grpc Java client to exercise a server
  * under test.
  *
- * <p>Essentially porting the client code from {@code io.grpc.testing.integration.AbstractInteropTest}
- * against our Scala API's
+ * <p>Essentially porting the client code from {@code
+ * io.grpc.testing.integration.AbstractInteropTest} against our Scala API's
  */
 public class PekkoGrpcJavaClientTester implements ClientTester {
 

--- a/sbt-plugin/src/sbt-test/gen-scala-server/00-interop/src/main/java/org/apache/pekko/grpc/JavaTestServiceImpl.java
+++ b/sbt-plugin/src/sbt-test/gen-scala-server/00-interop/src/main/java/org/apache/pekko/grpc/JavaTestServiceImpl.java
@@ -29,7 +29,7 @@ import io.grpc.testing.integration.TestService;
 /**
  * Implementation of the generated service.
  *
- * Essentially porting the client code from [[io.grpc.testing.integration.TestServiceImpl]] against our API's
+ * Essentially porting the client code from {@code io.grpc.testing.integration.TestServiceImpl} against our API's
  *
  * The same implementation is also be found as part of the 'non-scripted' tests at
  * /interop-tests/src/test/java/org/apache/pekko/grpc/interop/JavaTestServiceImpl.scala


### PR DESCRIPTION
## Motivation

Running `sbt doc` produces a javadoc warning in `JavaTestServiceImpl.java`:
- Scala-style `[[...]]` link is not recognized by javadoc

## Modification

- Replace `[[io.grpc.testing.integration.TestServiceImpl]]` with `{@code io.grpc.testing.integration.TestServiceImpl}`

## Result

Javadoc warning is eliminated.

## Tests

Not run - docs only

## References

None