### PR TITLE
fix: fix scaladoc warnings in runtime module

### DIFF
--- a/runtime/src/main/scala/org/apache/pekko/grpc/internal/Codec.scala
+++ b/runtime/src/main/scala/org/apache/pekko/grpc/internal/Codec.scala
@@ -23,7 +23,7 @@ abstract class Codec {
 
   /**
    * Process the given frame bytes, uncompress if the compression bit is set. Identity
-   * codec will fail with a [[io.grpc.StatusException]] if the compressedBit is set.
+   * codec will fail with a `io.grpc.StatusException` if the compressedBit is set.
    */
   def uncompress(compressedBitSet: Boolean, bytes: ByteString): ByteString
 

--- a/runtime/src/main/scala/org/apache/pekko/grpc/internal/Codecs.scala
+++ b/runtime/src/main/scala/org/apache/pekko/grpc/internal/Codecs.scala
@@ -59,7 +59,7 @@ object Codecs {
    * Determines the `Message-Encoding` specified in a message.
    *
    * @param message the gRPC message
-   * @return the specified codec to uncompress data frame bodies with, [[Identity]] if no encoding was specified, or [[Failure]] if an unsupported encoding was specified.
+   * @return the specified codec to uncompress data frame bodies with, [[Identity]] if no encoding was specified, or `Failure` if an unsupported encoding was specified.
    */
   def detect(message: jm.HttpMessage): Try[Codec] =
     detect(`Message-Encoding`.findIn(extractHeaders(message)))
@@ -68,7 +68,7 @@ object Codecs {
    * Determines the `Message-Encoding` specified in a gRPC stream to be unmarshalled.
    *
    * @param encoding the specified message encoding.
-   * @return the specified codec to uncompress data frame bodies with, [[Identity]] if no encoding was specified, or [[Failure]] if an unsupported encoding was specified.
+   * @return the specified codec to uncompress data frame bodies with, [[Identity]] if no encoding was specified, or `Failure` if an unsupported encoding was specified.
    */
   def detect(encoding: Option[String]): Try[Codec] =
     encoding

--- a/runtime/src/main/scala/org/apache/pekko/grpc/internal/GrpcProtocolNative.scala
+++ b/runtime/src/main/scala/org/apache/pekko/grpc/internal/GrpcProtocolNative.scala
@@ -35,8 +35,8 @@ import scala.collection.immutable
  * Implementation of the gRPC (`application/grpc+proto`) protocol:
  *
  * Protocol:
- *  - Data frames are encoded to a stream of [[Chunk]] as per the gRPC specification
- *  - Trailer frames are encoded to [[LastChunk]], to be rendered into the underlying HTTP/2 transport
+ *  - Data frames are encoded to a stream of `Chunk` as per the gRPC specification
+ *  - Trailer frames are encoded to `LastChunk`, to be rendered into the underlying HTTP/2 transport
  */
 object GrpcProtocolNative extends AbstractGrpcProtocol("grpc") {
 

--- a/runtime/src/main/scala/org/apache/pekko/grpc/internal/GrpcProtocolWeb.scala
+++ b/runtime/src/main/scala/org/apache/pekko/grpc/internal/GrpcProtocolWeb.scala
@@ -88,8 +88,8 @@ abstract class GrpcProtocolWebBase(subType: String) extends AbstractGrpcProtocol
  * Implementation of the gRPC Web protocol.
  *
  * Protocol:
- *  - Data frames are encoded to a stream of [[Chunk]] as per the gRPC-web specification.
- *  - Trailer frames are encoded to a [[Chunk]] (containing a marked trailer frame) as per the gRPC-web specification.
+ *  - Data frames are encoded to a stream of `Chunk` as per the gRPC-web specification.
+ *  - Trailer frames are encoded to a `Chunk` (containing a marked trailer frame) as per the gRPC-web specification.
  */
 object GrpcProtocolWeb extends GrpcProtocolWebBase("grpc-web") {
 

--- a/runtime/src/main/scala/org/apache/pekko/grpc/javadsl/package.scala
+++ b/runtime/src/main/scala/org/apache/pekko/grpc/javadsl/package.scala
@@ -20,7 +20,7 @@ import org.apache.pekko
 package object javadsl {
 
   /**
-   * Helper for creating Scala partial functions from [[pekko.japi.function.Function]]
+   * Helper for creating Scala partial functions from `pekko.japi.function.Function`
    * instances.
    */
   @deprecated("no longer needed since support for Scala 2.11 has been dropped", "1.2.0")
@@ -29,7 +29,7 @@ package object javadsl {
   }
 
   /**
-   * Helper for creating Scala anonymous partial functions from [[pekko.japi.function.Function]]
+   * Helper for creating Scala anonymous partial functions from `pekko.japi.function.Function`
    * instances.
    */
   @nowarn("msg=deprecated")

--- a/runtime/src/main/scala/org/apache/pekko/grpc/scaladsl/PekkoGrpcClient.scala
+++ b/runtime/src/main/scala/org/apache/pekko/grpc/scaladsl/PekkoGrpcClient.scala
@@ -29,7 +29,7 @@ trait PekkoGrpcClient {
    * This method is only valid for clients that use an internal channel. If the client was created
    * with a shared user-provided channel, the channel itself should be closed.
    *
-   * @throws org.apache.pekko.grpc.GrpcClientCloseException if client was created with a user-provided [[pekko.grpc.GrpcChannel]].
+   * @throws org.apache.pekko.grpc.GrpcClientCloseException if client was created with a user-provided `pekko.grpc.GrpcChannel`.
    */
   def close(): Future[Done]
 


### PR DESCRIPTION
Motivation:
The runtime module had 8 scaladoc warnings about unresolvable links for external types (`io.grpc.StatusException`, `scala.util.Failure`), pekko-http types (`Chunk`, `LastChunk`), and types with incorrect package prefixes (`pekko.japi.function.Function`, `pekko.grpc.GrpcChannel`).

Modification:
Replace unresolvable `[[...]]` scaladoc links with backtick-quoted code in 6 files:
- `Codec.scala`: `[[io.grpc.StatusException]]` → backtick-quoted code
- `Codecs.scala`: `[[Failure]]` → backtick-quoted code (2 places)
- `GrpcProtocolNative.scala`: `[[Chunk]]`, `[[LastChunk]]` → backtick-quoted code
- `GrpcProtocolWeb.scala`: `[[Chunk]]` → backtick-quoted code (2 places)
- `javadsl/package.scala`: `[[pekko.japi.function.Function]]` → backtick-quoted code (2 places)
- `scaladsl/PekkoGrpcClient.scala`: `[[pekko.grpc.GrpcChannel]]` → backtick-quoted code

Result:
All 8 scaladoc warnings in the runtime module are resolved. `sbt runtime/doc` completes with 0 warnings.