### PR TITLE
refactor: remove deprecated scalaPartialFunction (since 1.2.0)

### DIFF
--- a/runtime/src/main/mima-filters/2.0.x.backwards.excludes/remove-deprecated-methods.excludes
+++ b/runtime/src/main/mima-filters/2.0.x.backwards.excludes/remove-deprecated-methods.excludes
@@ -29,3 +29,4 @@ ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.pekko.grpc.javads
 ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.pekko.grpc.javadsl.package.javaFunction")
 ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.pekko.grpc.javadsl.package.japiFunction")
 ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.pekko.grpc.internal.ScalaServerStreamingRequestBuilder.this")
+ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.pekko.grpc.javadsl.package.scalaPartialFunction")

--- a/runtime/src/main/scala/org/apache/pekko/grpc/javadsl/package.scala
+++ b/runtime/src/main/scala/org/apache/pekko/grpc/javadsl/package.scala
@@ -13,27 +13,15 @@
 
 package org.apache.pekko.grpc
 
-import scala.annotation.nowarn
-
 import org.apache.pekko
 
 package object javadsl {
 
   /**
-   * Helper for creating Scala partial functions from [[pekko.japi.function.Function]]
-   * instances.
-   */
-  @deprecated("no longer needed since support for Scala 2.11 has been dropped", "1.2.0")
-  def scalaPartialFunction[A, B](f: pekko.japi.function.Function[A, B]): PartialFunction[A, B] = {
-    case a => f(a)
-  }
-
-  /**
    * Helper for creating Scala anonymous partial functions from [[pekko.japi.function.Function]]
    * instances.
    */
-  @nowarn("msg=deprecated")
   def scalaAnonymousPartialFunction[A, B, C](
       f: pekko.japi.function.Function[A, pekko.japi.function.Function[B, C]]): A => PartialFunction[B, C] =
-    a => scalaPartialFunction(f(a))
+    a => { case b => f(a)(b) }
 }


### PR DESCRIPTION
### Motivation
`scalaPartialFunction` was deprecated since pekko-grpc 1.2.0 as it is no longer needed since support for Scala 2.11 was dropped.

### Modification
Remove the deprecated `scalaPartialFunction` method and inline its logic into `scalaAnonymousPartialFunction`. Remove unused `@nowarn` import.

### Result
Cleaner API surface with one less deprecated method.

### Tests
Not run - trivial inline refactor

### References
None - deprecated API cleanup