### PR TITLE
Use StandardCharsets.UTF_8 for UTF-8 encoding

### DIFF
--- a/codegen/src/main/scala/org/apache/pekko/grpc/gen/Logging.scala
+++ b/codegen/src/main/scala/org/apache/pekko/grpc/gen/Logging.scala
@@ -14,6 +14,7 @@
 package org.apache.pekko.grpc.gen
 
 import java.io.PrintWriter
+import java.nio.charset.StandardCharsets
 
 // specific to gen so that the build tools can implement their own
 trait Logger {
@@ -41,7 +42,7 @@ object SilencedLogger extends Logger {
 }
 
 class FileLogger(path: String) extends Logger {
-  val printer = new PrintWriter(path, "UTF-8")
+  val printer = new PrintWriter(path, StandardCharsets.UTF_8)
   def debug(text: String): Unit = {
     printer.println(s"[debug] $text")
     printer.flush()

--- a/codegen/src/main/scala/org/apache/pekko/grpc/gen/Main.scala
+++ b/codegen/src/main/scala/org/apache/pekko/grpc/gen/Main.scala
@@ -15,6 +15,7 @@ package org.apache.pekko.grpc.gen
 
 import java.io.ByteArrayOutputStream
 import java.net.URLDecoder
+import java.nio.charset.StandardCharsets
 
 import com.google.protobuf.compiler.PluginProtos.CodeGeneratorRequest
 import org.apache.pekko
@@ -61,7 +62,7 @@ object Main {
     val logger: Logger =
       parameters
         .get("logfile_enc")
-        .map(URLDecoder.decode(_, "utf-8"))
+        .map(URLDecoder.decode(_, StandardCharsets.UTF_8))
         .orElse(parameters.get("logfile"))
         .map(new FileLogger(_))
         .getOrElse(SilencedLogger)

--- a/gradle-plugin/src/main/groovy/org/apache/pekko/grpc/gradle/PekkoGrpcPlugin.groovy
+++ b/gradle-plugin/src/main/groovy/org/apache/pekko/grpc/gradle/PekkoGrpcPlugin.groovy
@@ -21,6 +21,7 @@ import org.gradle.util.GradleVersion
 import org.gradle.util.VersionNumber
 
 import java.net.URLEncoder
+import java.nio.charset.StandardCharsets
 import java.nio.file.Files
 import java.nio.file.Path
 
@@ -133,7 +134,7 @@ class PekkoGrpcPlugin implements Plugin<Project> {
                             option "server_power_apis=${pekkoGrpcExt.serverPowerApis}"
                             option "use_play_actions=${pekkoGrpcExt.usePlayActions}"
                             option "extra_generators=${pekkoGrpcExt.extraGenerators.join(';')}"
-                            option "logfile_enc=${URLEncoder.encode(logFileRelative, "utf-8")}"
+                            option "logfile_enc=${URLEncoder.encode(logFileRelative, StandardCharsets.UTF_8)}"
                             if (pekkoGrpcExt.includeStdTypes) {
                                 option "include_std_types=true"
                             }

--- a/interop-tests/src/main/java/io/grpc/testing/integration2/TestServiceClient.java
+++ b/interop-tests/src/main/java/io/grpc/testing/integration2/TestServiceClient.java
@@ -24,6 +24,7 @@ import io.grpc.testing.integration.TestServiceGrpc;
 import java.io.File;
 import java.io.FileInputStream;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
 /**
  * Application that starts a client for the {@link TestServiceGrpc.TestServiceImplBase} and runs
@@ -31,7 +32,7 @@ import java.nio.charset.Charset;
  */
 public class TestServiceClient {
 
-  private static final Charset UTF_8 = Charset.forName("UTF-8");
+  private static final Charset UTF_8 = StandardCharsets.UTF_8;
 
   private String testCase = "empty_unary";
 

--- a/interop-tests/src/main/scala/org/apache/pekko/grpc/interop/PekkoGrpcServerScala.scala
+++ b/interop-tests/src/main/scala/org/apache/pekko/grpc/interop/PekkoGrpcServerScala.scala
@@ -14,6 +14,7 @@
 package org.apache.pekko.grpc.interop
 
 import java.io.FileInputStream
+import java.nio.charset.StandardCharsets
 import java.nio.file.{ Files, Paths }
 import java.security.cert.CertificateFactory
 import java.security.spec.PKCS8EncodedKeySpec
@@ -61,7 +62,8 @@ case class PekkoGrpcServerScala(serverHandlerFactory: ActorSystem => HttpRequest
 
   private def serverHttpContext() = {
     val keyEncoded =
-      new String(Files.readAllBytes(Paths.get(TestUtils.loadCert("server1.key").getAbsolutePath)), "UTF-8")
+      new String(Files.readAllBytes(Paths.get(TestUtils.loadCert("server1.key").getAbsolutePath)),
+        StandardCharsets.UTF_8)
         .replace("-----BEGIN PRIVATE KEY-----\n", "")
         .replace("-----END PRIVATE KEY-----\n", "")
         .replace("\n", "")

--- a/maven-plugin/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
+++ b/maven-plugin/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <lifecycleMappingMetadata>
     <pluginExecutions>
         <pluginExecution>

--- a/maven-plugin/src/main/scala/org/apache/pekko/grpc/maven/AbstractGenerateMojo.scala
+++ b/maven-plugin/src/main/scala/org/apache/pekko/grpc/maven/AbstractGenerateMojo.scala
@@ -14,6 +14,7 @@
 package org.apache.pekko.grpc.maven
 
 import java.io.{ ByteArrayOutputStream, File, PrintStream }
+import java.nio.charset.StandardCharsets
 
 import org.apache.pekko
 import pekko.grpc.gen.{ CodeGenerator, Logger, ProtocSettings }
@@ -47,9 +48,9 @@ object AbstractGenerateMojo {
 
   private def captureStdOutAndErr[T](block: => T): (String, String, T) = {
     val errBao = new ByteArrayOutputStream()
-    val errPrinter = new PrintStream(errBao, true, "UTF-8")
+    val errPrinter = new PrintStream(errBao, true, StandardCharsets.UTF_8)
     val outBao = new ByteArrayOutputStream()
-    val outPrinter = new PrintStream(outBao, true, "UTF-8")
+    val outPrinter = new PrintStream(outBao, true, StandardCharsets.UTF_8)
     val originalOut = System.out
     val originalErr = System.err
     System.setOut(outPrinter)
@@ -62,7 +63,7 @@ object AbstractGenerateMojo {
         System.setErr(originalErr)
       }
 
-    (outBao.toString("UTF-8"), errBao.toString("UTF-8"), t)
+    (outBao.toString(StandardCharsets.UTF_8), errBao.toString(StandardCharsets.UTF_8), t)
   }
 
   sealed trait Language {


### PR DESCRIPTION
Summary: Replace UTF-8 charset string arguments with StandardCharsets.UTF_8 in codegen, Maven plugin, Gradle plugin, and interop code, and normalize the m2e XML declaration. Verification: ran formatting, targeted sbt compile, Gradle compileGroovy, XML validation, git diff --check, and residual charset literal searches.