### PR TITLE
chore: update scala3Next to 3.9.0-RC3

### DIFF
--- a/interop-tests/src/test/scala/org/apache/pekko/grpc/interop/GrpcInteropSpec.scala
+++ b/interop-tests/src/test/scala/org/apache/pekko/grpc/interop/GrpcInteropSpec.scala
@@ -50,7 +50,7 @@ class GrpcInteropPekkoJavaWithPekkoHttpJavaSpec extends GrpcInteropTests(Servers
 object Servers {
   val IoGrpc = IoGrpcJavaServerProvider
   object Pekko {
-    val Java = PekkoHttpServerProviderJava$
+    val Java = PekkoHttpServerProviderJava
     val Scala = PekkoHttpServerProviderScala
   }
 }
@@ -73,7 +73,7 @@ object Clients {
 
 //--- Some more providers
 
-object PekkoHttpServerProviderJava$ extends PekkoHttpServerProvider {
+object PekkoHttpServerProviderJava extends PekkoHttpServerProvider {
   val label: String = "pekko-grpc java server"
 
   val pendingCases =

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -20,7 +20,7 @@ object Dependencies {
     val scala212 = "2.12.21"
     val scala213 = "2.13.18"
     val scala3 = "3.3.8"
-    val scala3Next = "3.8.4"
+    val scala3Next = "3.9.0-RC1"
 
     // the order in the list is important because the head will be considered the default.
     val CrossScalaForLib = Seq(scala213, scala3)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -20,7 +20,7 @@ object Dependencies {
     val scala212 = "2.12.21"
     val scala213 = "2.13.18"
     val scala3 = "3.3.8"
-    val scala3Next = "3.9.0-RC1"
+    val scala3Next = "3.9.0-RC3"
 
     // the order in the list is important because the head will be considered the default.
     val CrossScalaForLib = Seq(scala213, scala3)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -20,7 +20,7 @@ object Dependencies {
     val scala212 = "2.12.21"
     val scala213 = "2.13.18"
     val scala3 = "3.3.8"
-    val scala3Next = "3.9.0-RC3"
+    val scala3Next = "3.9.0-RC6"
 
     // the order in the list is important because the head will be considered the default.
     val CrossScalaForLib = Seq(scala213, scala3)


### PR DESCRIPTION
### Motivation
Scala 3.9.0-RC3 is available and should be tested as the next Scala version.

### Modification
Update scala3Next version from 3.8.4 to 3.9.0-RC3.

### Result
Build will use Scala 3.9.0-RC3 as the next Scala version.

### Tests
Not run - version bump only

### References
None - version bump