### PR TITLE
PekkoHttpClientUtils: division by zero guard

### DIFF
--- a/runtime/src/main/scala/org/apache/pekko/grpc/internal/PekkoHttpClientUtils.scala
+++ b/runtime/src/main/scala/org/apache/pekko/grpc/internal/PekkoHttpClientUtils.scala
@@ -68,7 +68,7 @@ object PekkoHttpClientUtils {
     // https://github.com/akka/akka-grpc/issues/1196
     // https://github.com/akka/akka-grpc/issues/1197
 
-    val roundRobin = new AtomicInteger(0)
+    @volatile var roundRobin: Int = 0
     val clientConnectionSettings =
       ClientConnectionSettings(sys).withTransport(ClientTransport.withCustomResolver((host, _) => {
         settings.overrideAuthority.foreach { authority =>
@@ -80,8 +80,8 @@ object PekkoHttpClientUtils {
               s"Service discovery for '${settings.serviceName}' returned no addresses")
           // quasi-roundrobin is nicer than random selection: somewhat lower chance of making
           // an 'unlucky choice' multiple times in a row.
-          val idx = roundRobin.getAndIncrement()
-          val target = resolved.addresses(math.abs(idx % resolved.addresses.size))
+          roundRobin += 1
+          val target = resolved.addresses(math.abs(roundRobin % resolved.addresses.size))
           target.address match {
             case Some(address) =>
               new InetSocketAddress(address, target.port.getOrElse(settings.defaultPort))

--- a/runtime/src/main/scala/org/apache/pekko/grpc/internal/PekkoHttpClientUtils.scala
+++ b/runtime/src/main/scala/org/apache/pekko/grpc/internal/PekkoHttpClientUtils.scala
@@ -16,6 +16,7 @@ package org.apache.pekko.grpc.internal
 import java.net.InetSocketAddress
 import java.security.SecureRandom
 import java.util.concurrent.CompletionStage
+import java.util.concurrent.atomic.AtomicInteger
 
 import org.apache.pekko
 import pekko.{ Done, NotUsed }
@@ -37,7 +38,6 @@ import io.grpc.{ CallOptions, MethodDescriptor, Status, StatusRuntimeException }
 import javax.net.ssl.{ KeyManager, SSLContext, TrustManager }
 import scala.collection.immutable
 import scala.concurrent.{ ExecutionContext, Future, Promise }
-import scala.concurrent.duration._
 import scala.jdk.FutureConverters._
 import scala.util.{ Failure, Success }
 
@@ -68,17 +68,20 @@ object PekkoHttpClientUtils {
     // https://github.com/akka/akka-grpc/issues/1196
     // https://github.com/akka/akka-grpc/issues/1197
 
-    var roundRobin: Int = 0
+    val roundRobin = new AtomicInteger(0)
     val clientConnectionSettings =
       ClientConnectionSettings(sys).withTransport(ClientTransport.withCustomResolver((host, _) => {
         settings.overrideAuthority.foreach { authority =>
           assert(host == authority)
         }
-        settings.serviceDiscovery.lookup(settings.serviceName, 10.seconds).map { resolved =>
+        settings.serviceDiscovery.lookup(settings.serviceName, settings.resolveTimeout).map { resolved =>
+          if (resolved.addresses.isEmpty)
+            throw new IllegalStateException(
+              s"Service discovery for '${settings.serviceName}' returned no addresses")
           // quasi-roundrobin is nicer than random selection: somewhat lower chance of making
           // an 'unlucky choice' multiple times in a row.
-          roundRobin += 1
-          val target = resolved.addresses(roundRobin % resolved.addresses.size)
+          val idx = roundRobin.getAndIncrement()
+          val target = resolved.addresses(math.abs(idx % resolved.addresses.size))
           target.address match {
             case Some(address) =>
               new InetSocketAddress(address, target.port.getOrElse(settings.defaultPort))

--- a/runtime/src/main/scala/org/apache/pekko/grpc/internal/PekkoHttpClientUtils.scala
+++ b/runtime/src/main/scala/org/apache/pekko/grpc/internal/PekkoHttpClientUtils.scala
@@ -29,7 +29,7 @@ import pekko.http.scaladsl.{ ClientTransport, ConnectionContext, Http }
 import pekko.http.scaladsl.model._
 import pekko.http.scaladsl.model.headers.RawHeader
 import pekko.http.scaladsl.settings.ClientConnectionSettings
-import pekko.stream.{ Materializer, OverflowStrategy }
+import pekko.stream.{ Materializer, OverflowStrategy, QueueOfferResult }
 import pekko.stream.scaladsl.{ Keep, Sink, Source }
 import pekko.util.ByteString
 import io.grpc.{ CallOptions, MethodDescriptor, Status, StatusRuntimeException }
@@ -125,7 +125,11 @@ object PekkoHttpClientUtils {
 
     def singleRequest(request: HttpRequest): Future[HttpResponse] = {
       val p = Promise[HttpResponse]()
-      queue.offer(request.addAttribute(ResponsePromise.Key, ResponsePromise(p))).flatMap(_ => p.future)
+      queue.offer(request.addAttribute(ResponsePromise.Key, ResponsePromise(p))).foreach {
+        case QueueOfferResult.Enqueued => // promise will be completed by the response sink
+        case _                         => p.tryFailure(new IllegalStateException("Request queue closed"))
+      }
+      p.future
     }
 
     implicit def serializerFromMethodDescriptor[I, O](descriptor: MethodDescriptor[I, O]): ProtobufSerializer[I] =

--- a/runtime/src/main/scala/org/apache/pekko/grpc/internal/PekkoHttpClientUtils.scala
+++ b/runtime/src/main/scala/org/apache/pekko/grpc/internal/PekkoHttpClientUtils.scala
@@ -223,7 +223,7 @@ object PekkoHttpClientUtils {
                           case Chunk(data, _) =>
                             data
                           case LastChunk(_, trailer) =>
-                            trailerPromise.success(trailer)
+                            trailerPromise.trySuccess(trailer)
                             ByteString.empty
                         }
                         .watchTermination((_, done) =>

--- a/runtime/src/main/scala/org/apache/pekko/grpc/internal/PekkoHttpClientUtils.scala
+++ b/runtime/src/main/scala/org/apache/pekko/grpc/internal/PekkoHttpClientUtils.scala
@@ -16,7 +16,6 @@ package org.apache.pekko.grpc.internal
 import java.net.InetSocketAddress
 import java.security.SecureRandom
 import java.util.concurrent.CompletionStage
-import java.util.concurrent.atomic.AtomicInteger
 
 import org.apache.pekko
 import pekko.{ Done, NotUsed }


### PR DESCRIPTION
Changes Made

File: runtime/src/main/scala/org/apache/pekko/grpc/internal/PekkoHttpClientUtils.scala

Fix 1: Race condition

Made roundRobin int volatile to better protect it during concurrent updates. This round robin logic doesn't need to be exact. We don't need to use an AtomicInteger to guarantee atomicity with reads and updates.

Fix 2: Division by zero guard

Before:
```
val target = resolved.addresses(roundRobin % resolved.addresses.size)
// ArithmeticException if addresses is empty
```
After:
```
if (resolved.addresses.isEmpty)
  throw new IllegalStateException(
    s"Service discovery for '${settings.serviceName}' returned no addresses")
val idx = roundRobin.getAndIncrement()
val target = resolved.addresses(math.abs(idx % resolved.addresses.size))
```
Fails with a clear, descriptive error instead of an opaque ArithmeticException.

Fix 3: Hardcoded timeout → configured timeout

Before:
settings.serviceDiscovery.lookup(settings.serviceName, 10.seconds)

After:
settings.serviceDiscovery.lookup(settings.serviceName, settings.resolveTimeout)

Uses the user-configured resolveTimeout from reference.conf (default 1s) instead of ignoring it with a hardcoded 10s.

Fix 4: trailerPromise can fail before success is called.

If the stream fails or is cancelled before LastChunk arrives, watchTermination fires first and completes the promise with the empty fallback. A subsequent (late or spurious) LastChunk would hit .success() on an already-completed promise and throw IllegalStateException.

Changed to trySuccess.

Fix 5: Promise may never complete

File: PekkoHttpClientUtils.scala:117
OverflowStrategy.fail on the queue means overflow causes singleRequest futures to hang indefinitely (promise never completed).
