### PR TITLE
add verify-hostname support

### DIFF
--- a/runtime/src/main/resources/reference.conf
+++ b/runtime/src/main/resources/reference.conf
@@ -38,6 +38,12 @@ pekko.grpc.client."*" {
   # leave empty to auto-detect, or configure 'jdk' or 'openssl'.
   ssl-provider = ""
 
+  # Whether to verify the server's hostname against its TLS certificate (RFC 2818).
+  # When false (the default), the client accepts any valid certificate regardless
+  # of hostname. This is insecure for production and should only be used for testing.
+  # Only effective for the pekko-http backend; the netty backend always verifies.
+  verify-hostname = false
+
   # TODO: Enforce HTTP/2 TLS restrictions: https://tools.ietf.org/html/draft-ietf-httpbis-http2-17#section-9.2
 
   # The number of times to try connecting before giving up.

--- a/runtime/src/main/scala/org/apache/pekko/grpc/GrpcClientSettings.scala
+++ b/runtime/src/main/scala/org/apache/pekko/grpc/GrpcClientSettings.scala
@@ -158,7 +158,8 @@ object GrpcClientSettings {
       getOptionalString(clientConfiguration, "user-agent"),
       clientConfiguration.getBoolean("use-tls"),
       getOptionalString(clientConfiguration, "load-balancing-policy"),
-      clientConfiguration.getString("backend"))
+      clientConfiguration.getString("backend"),
+      verifyHostname = clientConfiguration.getBoolean("verify-hostname"))
 
   private def getOptionalString(config: Config, path: String): Option[String] =
     config.getString(path) match {
@@ -206,7 +207,8 @@ final class GrpcClientSettings private (
     val useTls: Boolean,
     val loadBalancingPolicy: Option[String],
     val backend: String,
-    val channelBuilderOverrides: NettyChannelBuilder => NettyChannelBuilder = identity) {
+    val channelBuilderOverrides: NettyChannelBuilder => NettyChannelBuilder = identity,
+    val verifyHostname: Boolean) {
   require(
     sslContext.isEmpty || trustManager.isEmpty,
     "Configuring the sslContext or the trustManager is mutually exclusive")
@@ -289,6 +291,16 @@ final class GrpcClientSettings private (
   def withBackend(value: String): GrpcClientSettings =
     copy(backend = value)
 
+  /**
+   * Whether to verify the server's hostname against its TLS certificate (RFC 2818).
+   * When false (the default), the client accepts any valid certificate regardless
+   * of hostname. This is insecure for production and should only be used for testing.
+   * Only effective for the pekko-http backend; the netty backend always verifies.
+   * @since 2.0.0
+   */
+  def withVerifyHostname(value: Boolean): GrpcClientSettings =
+    copy(verifyHostname = value)
+
   private def copy(
       serviceName: String = serviceName,
       servicePortName: Option[String] = servicePortName,
@@ -306,7 +318,8 @@ final class GrpcClientSettings private (
       connectionAttempts: Option[Int] = connectionAttempts,
       loadBalancingPolicy: Option[String] = loadBalancingPolicy,
       backend: String = backend,
-      channelBuilderOverrides: NettyChannelBuilder => NettyChannelBuilder = channelBuilderOverrides)
+      channelBuilderOverrides: NettyChannelBuilder => NettyChannelBuilder = channelBuilderOverrides,
+      verifyHostname: Boolean = verifyHostname)
       : GrpcClientSettings =
     new GrpcClientSettings(
       callCredentials = callCredentials,
@@ -326,5 +339,6 @@ final class GrpcClientSettings private (
       connectionAttempts = connectionAttempts,
       loadBalancingPolicy = loadBalancingPolicy,
       backend = backend,
-      channelBuilderOverrides = channelBuilderOverrides)
+      channelBuilderOverrides = channelBuilderOverrides,
+      verifyHostname = verifyHostname)
 }

--- a/runtime/src/main/scala/org/apache/pekko/grpc/internal/PekkoHttpClientUtils.scala
+++ b/runtime/src/main/scala/org/apache/pekko/grpc/internal/PekkoHttpClientUtils.scala
@@ -94,18 +94,34 @@ object PekkoHttpClientUtils {
 
     val http2client =
       if (settings.useTls) {
-        val connectionContext =
-          ConnectionContext.httpsClient {
-            settings.sslContext.getOrElse {
-              settings.trustManager match {
-                case None               => SSLContext.getDefault
-                case Some(trustManager) =>
-                  val sslContext: SSLContext = SSLContext.getInstance("TLS")
-                  sslContext.init(Array[KeyManager](), Array[TrustManager](trustManager), new SecureRandom)
-                  sslContext
-              }
+        if (!settings.verifyHostname) {
+          log.warning(
+            "TLS hostname verification is disabled for pekko-http client '{}'. " +
+            "This is insecure and should only be used for testing. " +
+            "Enable it with verify-hostname = true in your configuration. " +
+            "Note: the netty backend always verifies hostnames.",
+            settings.serviceName)
+        }
+        val sslContext =
+          settings.sslContext.getOrElse {
+            settings.trustManager match {
+              case None               => SSLContext.getDefault
+              case Some(trustManager) =>
+                val ctx: SSLContext = SSLContext.getInstance("TLS")
+                ctx.init(Array[KeyManager](), Array[TrustManager](trustManager), new SecureRandom)
+                ctx
             }
           }
+        val connectionContext =
+          ConnectionContext.httpsClient((hostname, port) => {
+            val engine = sslContext.createSSLEngine(hostname, port)
+            if (settings.verifyHostname) {
+              val sslParams = engine.getSSLParameters
+              sslParams.setEndpointIdentificationAlgorithm("HTTPS")
+              engine.setSSLParameters(sslParams)
+            }
+            engine
+          })
 
         builder.withCustomHttpsConnectionContext(connectionContext).managedPersistentHttp2()
       } else {


### PR DESCRIPTION
Problem

The Pekko HTTP client backend (PekkoHttpClientUtils) never called setEndpointIdentificationAlgorithm("HTTPS") on the SSLEngine. This meant no RFC 2818 hostname verification — the client would accept any valid certificate regardless of hostname, enabling MitM attacks. The Netty backend was not affected (gRPC-shaded Netty verifies by default).

Solution: Opt-in config with warning

reference.conf — new config key:
hocon
```
verify-hostname = false
```
Default is false (preserves existing behavior). The warning in the log nudges users toward enabling it.

GrpcClientSettings — new field and setter:
- verifyHostname: Boolean — read from config
- withVerifyHostname(value: Boolean) — programmatic override

PekkoHttpClientUtils — conditional verification:
- When verifyHostname = true: sets setEndpointIdentificationAlgorithm("HTTPS") on the SSLEngine, enabling hostname checking
- When verifyHostname = false: skips the setting (existing behavior), logs a warning once per channel creation:
▎ TLS hostname verification is disabled for pekko-http client 'X'. This is insecure and should only be used for testing. Enable it with verify-hostname = true in your configuration. Note: the netty backend always verifies hostnames.

Usage

hocon
```
pekko.grpc.client."*" {
  verify-hostname = true
}
```

Or programmatically:
```
val settings = GrpcClientSettings.connectToServiceAt("localhost", 8080)
  .withVerifyHostname(true)
```