### PR TITLE
mark headers field as volatile

### DIFF
--- a/runtime/src/main/scala/org/apache/pekko/grpc/internal/UnaryCallAdapter.scala
+++ b/runtime/src/main/scala/org/apache/pekko/grpc/internal/UnaryCallAdapter.scala
@@ -63,7 +63,7 @@ private[pekko] final class UnaryCallAdapter[Res] extends ClientCall.Listener[Res
 @InternalApi
 private[pekko] final class UnaryCallWithMetadataAdapter[Res] extends ClientCall.Listener[Res] {
   private val responsePromise = Promise[GrpcSingleResponse[Res]]()
-  private var headers: OptionVal[Metadata] = OptionVal.None
+  @volatile private var headers: OptionVal[Metadata] = OptionVal.None
   private val trailerPromise = Promise[Metadata]()
 
   // always invoked before message


### PR DESCRIPTION
`@volatile` establishes the happens-before edge: onHeaders flushes the write to main memory, onMessage reads from main memory instead of a stale thread-local cache.