### PR TITLE
Minimum TLS version setting

### DIFF
--- a/runtime/src/main/resources/reference.conf
+++ b/runtime/src/main/resources/reference.conf
@@ -44,6 +44,12 @@ pekko.grpc.client."*" {
   # Only effective for the pekko-http backend; the netty backend always verifies.
   verify-hostname = true
 
+  # Minimum TLS protocol version to negotiate. Leave empty (the default) to use whatever
+  # the JDK enables; on a supported JDK that is already TLSv1.2 and above. Set this to
+  # require a floor of your own, for example to refuse anything below TLSv1.3.
+  # Accepted values: "", "TLSv1.2", "TLSv1.3"
+  minimum-tls-version = ""
+
   # TODO: Enforce HTTP/2 TLS restrictions: https://tools.ietf.org/html/draft-ietf-httpbis-http2-17#section-9.2
 
   # Maximum allowed size for inbound gRPC messages (in bytes).

--- a/runtime/src/main/resources/reference.conf
+++ b/runtime/src/main/resources/reference.conf
@@ -38,6 +38,10 @@ pekko.grpc.client."*" {
   # leave empty to auto-detect, or configure 'jdk' or 'openssl'.
   ssl-provider = ""
 
+  # Minimum TLS protocol version. Leave empty to allow all JDK-supported versions.
+  # Accepted values: "TLSv1.2", "TLSv1.3"
+  minimum-tls-version = "TLSv1.2"
+
   # TODO: Enforce HTTP/2 TLS restrictions: https://tools.ietf.org/html/draft-ietf-httpbis-http2-17#section-9.2
 
   # The number of times to try connecting before giving up.

--- a/runtime/src/main/scala/org/apache/pekko/grpc/GrpcClientSettings.scala
+++ b/runtime/src/main/scala/org/apache/pekko/grpc/GrpcClientSettings.scala
@@ -158,7 +158,8 @@ object GrpcClientSettings {
       getOptionalString(clientConfiguration, "user-agent"),
       clientConfiguration.getBoolean("use-tls"),
       getOptionalString(clientConfiguration, "load-balancing-policy"),
-      clientConfiguration.getString("backend"))
+      clientConfiguration.getString("backend"),
+      getOptionalString(clientConfiguration, "minimum-tls-version"))
 
   private def getOptionalString(config: Config, path: String): Option[String] =
     config.getString(path) match {
@@ -206,6 +207,7 @@ final class GrpcClientSettings private (
     val useTls: Boolean,
     val loadBalancingPolicy: Option[String],
     val backend: String,
+    val minimumTlsVersion: Option[String],
     val channelBuilderOverrides: NettyChannelBuilder => NettyChannelBuilder = identity) {
   require(
     sslContext.isEmpty || trustManager.isEmpty,
@@ -270,6 +272,14 @@ final class GrpcClientSettings private (
     copy(loadBalancingPolicy = Some(loadBalancingPolicy))
 
   /**
+   * Set the minimum TLS protocol version to use. Accepted values: "TLSv1.2", "TLSv1.3".
+   * On older JDKs that do not support the specified version, the connection will fail.
+   * @since 2.0.0
+   */
+  def withMinimumTlsVersion(version: String): GrpcClientSettings =
+    copy(minimumTlsVersion = Some(version))
+
+  /**
    * How many times to retry establishing a connection before failing the client
    * Failure can be monitored using client.stopped and monitoring the Future/CompletionStage.
    * An exponentially increasing backoff is used between attempts.
@@ -306,6 +316,7 @@ final class GrpcClientSettings private (
       connectionAttempts: Option[Int] = connectionAttempts,
       loadBalancingPolicy: Option[String] = loadBalancingPolicy,
       backend: String = backend,
+      minimumTlsVersion: Option[String] = minimumTlsVersion,
       channelBuilderOverrides: NettyChannelBuilder => NettyChannelBuilder = channelBuilderOverrides)
       : GrpcClientSettings =
     new GrpcClientSettings(
@@ -326,5 +337,6 @@ final class GrpcClientSettings private (
       connectionAttempts = connectionAttempts,
       loadBalancingPolicy = loadBalancingPolicy,
       backend = backend,
+      minimumTlsVersion = minimumTlsVersion,
       channelBuilderOverrides = channelBuilderOverrides)
 }

--- a/runtime/src/main/scala/org/apache/pekko/grpc/GrpcClientSettings.scala
+++ b/runtime/src/main/scala/org/apache/pekko/grpc/GrpcClientSettings.scala
@@ -163,7 +163,8 @@ object GrpcClientSettings {
         clientConfiguration,
         "max-inbound-message-size",
         AbstractGrpcProtocol.DefaultMaxInboundMessageSize),
-      verifyHostname = clientConfiguration.getBoolean("verify-hostname"))
+      verifyHostname = clientConfiguration.getBoolean("verify-hostname"),
+      minimumTlsVersion = getOptionalString(clientConfiguration, "minimum-tls-version"))
 
   // `fromConfig(Config)` is public API and is called with hand-assembled Configs that do not
   // necessarily fall back on `pekko.grpc.client."*"`, so a missing key must not fail.
@@ -218,7 +219,8 @@ final class GrpcClientSettings private (
     val backend: String,
     val channelBuilderOverrides: NettyChannelBuilder => NettyChannelBuilder = identity,
     val maxInboundMessageSize: Int,
-    val verifyHostname: Boolean) {
+    val verifyHostname: Boolean,
+    val minimumTlsVersion: Option[String]) {
   require(
     sslContext.isEmpty || trustManager.isEmpty,
     "Configuring the sslContext or the trustManager is mutually exclusive")
@@ -285,6 +287,14 @@ final class GrpcClientSettings private (
     copy(loadBalancingPolicy = Some(loadBalancingPolicy))
 
   /**
+   * Set the minimum TLS protocol version to use. Accepted values: "TLSv1.2", "TLSv1.3".
+   * On older JDKs that do not support the specified version, the connection will fail.
+   * @since 2.0.0
+   */
+  def withMinimumTlsVersion(version: String): GrpcClientSettings =
+    copy(minimumTlsVersion = Some(version))
+
+  /**
    * How many times to retry establishing a connection before failing the client
    * Failure can be monitored using client.stopped and monitoring the Future/CompletionStage.
    * An exponentially increasing backoff is used between attempts.
@@ -342,7 +352,8 @@ final class GrpcClientSettings private (
       backend: String = backend,
       channelBuilderOverrides: NettyChannelBuilder => NettyChannelBuilder = channelBuilderOverrides,
       maxInboundMessageSize: Int = maxInboundMessageSize,
-      verifyHostname: Boolean = verifyHostname)
+      verifyHostname: Boolean = verifyHostname,
+      minimumTlsVersion: Option[String] = minimumTlsVersion)
       : GrpcClientSettings =
     new GrpcClientSettings(
       callCredentials = callCredentials,
@@ -364,5 +375,6 @@ final class GrpcClientSettings private (
       backend = backend,
       channelBuilderOverrides = channelBuilderOverrides,
       maxInboundMessageSize = maxInboundMessageSize,
-      verifyHostname = verifyHostname)
+      verifyHostname = verifyHostname,
+      minimumTlsVersion = minimumTlsVersion)
 }

--- a/runtime/src/main/scala/org/apache/pekko/grpc/SSLContextUtils.scala
+++ b/runtime/src/main/scala/org/apache/pekko/grpc/SSLContextUtils.scala
@@ -17,7 +17,7 @@ import java.io.{ BufferedInputStream, IOException, InputStream }
 import java.security.KeyStore
 import java.security.cert.{ CertificateFactory, X509Certificate }
 
-import javax.net.ssl.{ TrustManager, TrustManagerFactory }
+import javax.net.ssl.{ SSLContext, SSLContextSpi, SSLEngine, SSLParameters, TrustManager, TrustManagerFactory }
 
 object SSLContextUtils {
   def trustManagerFromStream(certStream: InputStream): TrustManager = {
@@ -43,5 +43,87 @@ object SSLContextUtils {
     val certStream: InputStream = getClass.getResourceAsStream(certificateResourcePath)
     if (certStream == null) throw new IOException(s"Couldn't find '$certificateResourcePath' on the classpath")
     trustManagerFromStream(certStream)
+  }
+
+  /**
+   * Known TLS protocol versions in ascending order of strength.
+   * Used to filter protocols based on a minimum version requirement.
+   */
+  private val TlsVersionOrder: List[String] =
+    List("TLSv1.2", "TLSv1.3")
+
+  /**
+   * Returns the TLS protocols supported by the given SSLContext that are at or above
+   * the specified minimum version. Throws IllegalArgumentException if the minimum
+   * version is not a known TLS protocol name.
+   */
+  def enabledProtocols(sslContext: SSLContext, minimumVersion: String): Array[String] = {
+    val minIndex = TlsVersionOrder.indexOf(minimumVersion)
+    if (minIndex < 0)
+      throw new IllegalArgumentException(
+        s"Unknown TLS version '$minimumVersion'. Expected one of: ${TlsVersionOrder.mkString(", ")}")
+    val supported = sslContext.getDefaultSSLParameters.getProtocols
+    filterProtocols(supported, minIndex)
+  }
+
+  /**
+   * Returns TLS protocols from the given list that are at or above the specified minimum version.
+   */
+  def enabledProtocols(supportedProtocols: Array[String], minimumVersion: String): Array[String] = {
+    val minIndex = TlsVersionOrder.indexOf(minimumVersion)
+    if (minIndex < 0)
+      throw new IllegalArgumentException(
+        s"Unknown TLS version '$minimumVersion'. Expected one of: ${TlsVersionOrder.mkString(", ")}")
+    filterProtocols(supportedProtocols, minIndex)
+  }
+
+  private def filterProtocols(supported: Array[String], minIndex: Int): Array[String] = {
+    val allowed = TlsVersionOrder.drop(minIndex).toSet
+    val filtered = supported.filter(allowed.contains)
+    if (filtered.isEmpty)
+      throw new IllegalStateException(
+        s"No TLS protocols at or above ${TlsVersionOrder(minIndex)} are supported. " +
+        s"Supported protocols: ${supported.mkString(", ")}")
+    filtered
+  }
+
+  /**
+   * Wraps an SSLContext so that all SSLEngines created from it will only allow
+   * protocols at or above the specified minimum TLS version.
+   */
+  def withMinimumTlsVersion(sslContext: SSLContext, minimumVersion: String): SSLContext = {
+    val protocols = enabledProtocols(sslContext, minimumVersion)
+    new SSLContext(new SSLContextSpi {
+        override def engineCreateSSLEngine(): SSLEngine = {
+          val engine = sslContext.createSSLEngine()
+          engine.setEnabledProtocols(protocols)
+          engine
+        }
+        override def engineCreateSSLEngine(host: String, port: Int): SSLEngine = {
+          val engine = sslContext.createSSLEngine(host, port)
+          engine.setEnabledProtocols(protocols)
+          engine
+        }
+        override def engineInit(
+            km: Array[javax.net.ssl.KeyManager],
+            tm: Array[TrustManager],
+            random: java.security.SecureRandom): Unit =
+          sslContext.init(km, tm, random)
+        override def engineGetSocketFactory: javax.net.ssl.SSLSocketFactory = sslContext.getSocketFactory
+        override def engineGetServerSocketFactory: javax.net.ssl.SSLServerSocketFactory =
+          sslContext.getServerSocketFactory
+        override def engineGetServerSessionContext: javax.net.ssl.SSLSessionContext = sslContext.getServerSessionContext
+        override def engineGetClientSessionContext: javax.net.ssl.SSLSessionContext = sslContext.getClientSessionContext
+        override def engineGetDefaultSSLParameters: SSLParameters = {
+          val params = sslContext.getDefaultSSLParameters
+          params.setProtocols(protocols)
+          params
+        }
+        override def engineGetSupportedSSLParameters: SSLParameters = {
+          val params = sslContext.getSupportedSSLParameters
+          params.setProtocols(protocols)
+          params
+        }
+      }, sslContext.getProvider, sslContext.getProtocol) {}
   }
 }

--- a/runtime/src/main/scala/org/apache/pekko/grpc/SSLContextUtils.scala
+++ b/runtime/src/main/scala/org/apache/pekko/grpc/SSLContextUtils.scala
@@ -17,7 +17,7 @@ import java.io.{ BufferedInputStream, IOException, InputStream }
 import java.security.KeyStore
 import java.security.cert.{ CertificateFactory, X509Certificate }
 
-import javax.net.ssl.{ TrustManager, TrustManagerFactory }
+import javax.net.ssl.{ SSLContext, SSLContextSpi, SSLEngine, SSLParameters, TrustManager, TrustManagerFactory }
 
 object SSLContextUtils {
   def trustManagerFromStream(certStream: InputStream): TrustManager = {
@@ -43,5 +43,91 @@ object SSLContextUtils {
     val certStream: InputStream = getClass.getResourceAsStream(certificateResourcePath)
     if (certStream == null) throw new IOException(s"Couldn't find '$certificateResourcePath' on the classpath")
     trustManagerFromStream(certStream)
+  }
+
+  /**
+   * Known TLS protocol versions in ascending order of strength.
+   * Used to filter protocols based on a minimum version requirement.
+   */
+  private val TlsVersionOrder: List[String] =
+    List("TLSv1.2", "TLSv1.3")
+
+  /**
+   * Returns the TLS protocols supported by the given SSLContext that are at or above
+   * the specified minimum version. Throws IllegalArgumentException if the minimum
+   * version is not a known TLS protocol name.
+   *
+   * Reads the *supported* parameters rather than the default (enabled) ones: the minimum
+   * version is a floor on what may be negotiated, so a version the JDK supports but does not
+   * enable by default should still be reachable by configuring it explicitly.
+   */
+  def enabledProtocols(sslContext: SSLContext, minimumVersion: String): Array[String] = {
+    val minIndex = TlsVersionOrder.indexOf(minimumVersion)
+    if (minIndex < 0)
+      throw new IllegalArgumentException(
+        s"Unknown TLS version '$minimumVersion'. Expected one of: ${TlsVersionOrder.mkString(", ")}")
+    val supported = sslContext.getSupportedSSLParameters.getProtocols
+    filterProtocols(supported, minIndex)
+  }
+
+  /**
+   * Returns TLS protocols from the given list that are at or above the specified minimum version.
+   */
+  def enabledProtocols(supportedProtocols: Array[String], minimumVersion: String): Array[String] = {
+    val minIndex = TlsVersionOrder.indexOf(minimumVersion)
+    if (minIndex < 0)
+      throw new IllegalArgumentException(
+        s"Unknown TLS version '$minimumVersion'. Expected one of: ${TlsVersionOrder.mkString(", ")}")
+    filterProtocols(supportedProtocols, minIndex)
+  }
+
+  private def filterProtocols(supported: Array[String], minIndex: Int): Array[String] = {
+    val allowed = TlsVersionOrder.drop(minIndex).toSet
+    val filtered = supported.filter(allowed.contains)
+    if (filtered.isEmpty)
+      throw new IllegalStateException(
+        s"No TLS protocols at or above ${TlsVersionOrder(minIndex)} are supported. " +
+        s"Supported protocols: ${supported.mkString(", ")}")
+    filtered
+  }
+
+  /**
+   * Wraps an SSLContext so that all SSLEngines created from it will only allow
+   * protocols at or above the specified minimum TLS version.
+   */
+  def withMinimumTlsVersion(sslContext: SSLContext, minimumVersion: String): SSLContext = {
+    val protocols = enabledProtocols(sslContext, minimumVersion)
+    new SSLContext(new SSLContextSpi {
+        override def engineCreateSSLEngine(): SSLEngine = {
+          val engine = sslContext.createSSLEngine()
+          engine.setEnabledProtocols(protocols)
+          engine
+        }
+        override def engineCreateSSLEngine(host: String, port: Int): SSLEngine = {
+          val engine = sslContext.createSSLEngine(host, port)
+          engine.setEnabledProtocols(protocols)
+          engine
+        }
+        override def engineInit(
+            km: Array[javax.net.ssl.KeyManager],
+            tm: Array[TrustManager],
+            random: java.security.SecureRandom): Unit =
+          sslContext.init(km, tm, random)
+        override def engineGetSocketFactory: javax.net.ssl.SSLSocketFactory = sslContext.getSocketFactory
+        override def engineGetServerSocketFactory: javax.net.ssl.SSLServerSocketFactory =
+          sslContext.getServerSocketFactory
+        override def engineGetServerSessionContext: javax.net.ssl.SSLSessionContext = sslContext.getServerSessionContext
+        override def engineGetClientSessionContext: javax.net.ssl.SSLSessionContext = sslContext.getClientSessionContext
+        override def engineGetDefaultSSLParameters: SSLParameters = {
+          val params = sslContext.getDefaultSSLParameters
+          params.setProtocols(protocols)
+          params
+        }
+        override def engineGetSupportedSSLParameters: SSLParameters = {
+          val params = sslContext.getSupportedSSLParameters
+          params.setProtocols(protocols)
+          params
+        }
+      }, sslContext.getProvider, sslContext.getProtocol) {}
   }
 }

--- a/runtime/src/main/scala/org/apache/pekko/grpc/internal/NettyClientUtils.scala
+++ b/runtime/src/main/scala/org/apache/pekko/grpc/internal/NettyClientUtils.scala
@@ -31,6 +31,7 @@ import io.grpc.netty.shaded.io.netty.handler.ssl.{ SslContext, SslContextBuilder
 import scala.annotation.nowarn
 import scala.concurrent.duration.FiniteDuration
 import scala.concurrent.{ ExecutionContext, Future, Promise }
+import scala.jdk.CollectionConverters._
 import scala.util.{ Failure, Success }
 
 /**
@@ -86,12 +87,11 @@ object NettyClientUtils {
                 case Some(trustManager) => context.trustManager(trustManager)
               }
               settings.minimumTlsVersion.foreach { v =>
-                withTm.protocols(
-                  SSLContextUtils
-                    .enabledProtocols(
-                      javax.net.ssl.SSLContext.getDefault.getDefaultSSLParameters.getProtocols,
-                      v)
-                    .toIndexedSeq: _*)
+                withTm.protocols(SSLContextUtils
+                  .enabledProtocols(
+                    javax.net.ssl.SSLContext.getDefault.getDefaultSSLParameters.getProtocols,
+                    v)
+                  .toSeq.asJava)
               }
               builder.sslContext(withTm.build())
           }

--- a/runtime/src/main/scala/org/apache/pekko/grpc/internal/NettyClientUtils.scala
+++ b/runtime/src/main/scala/org/apache/pekko/grpc/internal/NettyClientUtils.scala
@@ -20,7 +20,7 @@ import org.apache.pekko
 import pekko.{ Done, NotUsed }
 import pekko.annotation.InternalApi
 import pekko.event.LoggingAdapter
-import pekko.grpc.{ GrpcClientSettings, GrpcResponseMetadata, GrpcSingleResponse }
+import pekko.grpc.{ GrpcClientSettings, GrpcResponseMetadata, GrpcSingleResponse, SSLContextUtils }
 import pekko.stream.scaladsl.{ Flow, Keep, Source }
 import io.grpc.{ CallOptions, MethodDescriptor }
 import io.grpc.netty.shaded.io.grpc.netty.GrpcSslContexts
@@ -69,7 +69,7 @@ object NettyClientUtils {
       builder = builder.negotiationType(NegotiationType.TLS)
       builder = settings.sslContext match {
         case Some(sslContext) =>
-          builder.sslContext(createNettySslContext(sslContext))
+          builder.sslContext(createNettySslContext(sslContext, settings.minimumTlsVersion))
         case None =>
           (settings.trustManager, settings.sslProvider) match {
             case (None, None) =>
@@ -81,10 +81,19 @@ object NettyClientUtils {
                 case Some(sslProvider) =>
                   GrpcSslContexts.configure(SslContextBuilder.forClient(), sslProvider)
               }
-              builder.sslContext((tm match {
+              val withTm = tm match {
                 case None               => context
                 case Some(trustManager) => context.trustManager(trustManager)
-              }).build())
+              }
+              settings.minimumTlsVersion.foreach { v =>
+                withTm.protocols(
+                  SSLContextUtils
+                    .enabledProtocols(
+                      javax.net.ssl.SSLContext.getDefault.getDefaultSSLParameters.getProtocols,
+                      v)
+                    .toIndexedSeq: _*)
+              }
+              builder.sslContext(withTm.build())
           }
       }
     }
@@ -182,10 +191,14 @@ object NettyClientUtils {
    * a Netty HTTP/2 channel.
    */
   @InternalApi
-  private def createNettySslContext(javaSslContext: SSLContext): SslContext = {
+  private def createNettySslContext(javaSslContext: SSLContext, minimumTlsVersion: Option[String]): SslContext = {
     import io.grpc.netty.shaded.io.netty.handler.ssl.{ ApplicationProtocolConfig, ClientAuth, JdkSslContext }
     import io.grpc.netty.shaded.io.netty.handler.codec.http2.Http2SecurityUtil
     import io.grpc.netty.shaded.io.netty.handler.ssl.SupportedCipherSuiteFilter
+    val protocols: Array[String] = minimumTlsVersion match {
+      case Some(v) => SSLContextUtils.enabledProtocols(javaSslContext, v)
+      case None    => null // use JDK defaults (null is accepted as indicated in constructor Javadoc)
+    }
     // See
     // https://github.com/netty/netty/blob/4.1/handler/src/main/java/io/netty/handler/ssl/JdkSslContext.java#L229-L309
     new JdkSslContext(
@@ -200,7 +213,7 @@ object NettyClientUtils {
         ApplicationProtocolConfig.SelectedListenerFailureBehavior.ACCEPT,
         "h2"),
       ClientAuth.NONE, // server-only option, which is ignored as isClient=true (as indicated in constructor Javadoc)
-      /* String[] protocols */ null, // use JDK defaults (null is accepted as indicated in constructor Javadoc)
+      protocols,
       /* boolean startTls */ false)
   }
 

--- a/runtime/src/main/scala/org/apache/pekko/grpc/internal/NettyClientUtils.scala
+++ b/runtime/src/main/scala/org/apache/pekko/grpc/internal/NettyClientUtils.scala
@@ -20,7 +20,7 @@ import org.apache.pekko
 import pekko.{ Done, NotUsed }
 import pekko.annotation.InternalApi
 import pekko.event.LoggingAdapter
-import pekko.grpc.{ GrpcClientSettings, GrpcResponseMetadata, GrpcSingleResponse }
+import pekko.grpc.{ GrpcClientSettings, GrpcResponseMetadata, GrpcSingleResponse, SSLContextUtils }
 import pekko.stream.scaladsl.{ Flow, Keep, Source }
 import io.grpc.{ CallOptions, MethodDescriptor }
 import io.grpc.netty.shaded.io.grpc.netty.GrpcSslContexts
@@ -31,6 +31,7 @@ import io.grpc.netty.shaded.io.netty.handler.ssl.{ SslContext, SslContextBuilder
 import scala.annotation.nowarn
 import scala.concurrent.duration.FiniteDuration
 import scala.concurrent.{ ExecutionContext, Future, Promise }
+import scala.jdk.CollectionConverters._
 import scala.util.{ Failure, Success }
 
 /**
@@ -76,25 +77,9 @@ object NettyClientUtils {
           "Use the pekko-http backend if you need to disable verification.",
           settings.serviceName)
       builder = builder.negotiationType(NegotiationType.TLS)
-      builder = settings.sslContext match {
-        case Some(sslContext) =>
-          builder.sslContext(createNettySslContext(sslContext))
-        case None =>
-          (settings.trustManager, settings.sslProvider) match {
-            case (None, None) =>
-              builder
-            case (tm, provider) =>
-              val context = provider match {
-                case None =>
-                  GrpcSslContexts.configure(SslContextBuilder.forClient())
-                case Some(sslProvider) =>
-                  GrpcSslContexts.configure(SslContextBuilder.forClient(), sslProvider)
-              }
-              builder.sslContext((tm match {
-                case None               => context
-                case Some(trustManager) => context.trustManager(trustManager)
-              }).build())
-          }
+      builder = nettySslContext(settings) match {
+        case Some(sslContext) => builder.sslContext(sslContext)
+        case None             => builder
       }
     }
 
@@ -189,14 +174,59 @@ object NettyClientUtils {
   /**
    * INTERNAL API
    *
+   * The Netty `SslContext` for these settings, or `None` when nothing is configured that
+   * grpc-java's own default client context does not already cover.
+   *
+   * `minimumTlsVersion` has to be part of that decision: with stock trust settings it is the
+   * only reason to build a context at all, and leaving it out of the match is how the setting
+   * came to be silently ignored on the default backend.
+   */
+  @InternalApi
+  private[grpc] def nettySslContext(settings: GrpcClientSettings): Option[SslContext] =
+    settings.sslContext match {
+      case Some(sslContext) =>
+        Some(createNettySslContext(sslContext, settings.minimumTlsVersion))
+      case None =>
+        (settings.trustManager, settings.sslProvider, settings.minimumTlsVersion) match {
+          case (None, None, None) =>
+            // nothing to configure: grpc-java builds its own client SslContext
+            None
+          case (tm, provider, minimumTlsVersion) =>
+            val context = provider match {
+              case None =>
+                GrpcSslContexts.configure(SslContextBuilder.forClient())
+              case Some(sslProvider) =>
+                GrpcSslContexts.configure(SslContextBuilder.forClient(), sslProvider)
+            }
+            val withTm = tm match {
+              case None               => context
+              case Some(trustManager) => context.trustManager(trustManager)
+            }
+            // `protocols` mutates the builder and returns it, so the result is the same instance
+            val withProtocols = minimumTlsVersion match {
+              case None    => withTm
+              case Some(v) =>
+                withTm.protocols(SSLContextUtils.enabledProtocols(SSLContext.getDefault, v).toSeq.asJava)
+            }
+            Some(withProtocols.build())
+        }
+    }
+
+  /**
+   * INTERNAL API
+   *
    * Given a Java [[SSLContext]], create a Netty [[SslContext]] that can be used to build
    * a Netty HTTP/2 channel.
    */
   @InternalApi
-  private def createNettySslContext(javaSslContext: SSLContext): SslContext = {
+  private def createNettySslContext(javaSslContext: SSLContext, minimumTlsVersion: Option[String]): SslContext = {
     import io.grpc.netty.shaded.io.netty.handler.ssl.{ ApplicationProtocolConfig, ClientAuth, JdkSslContext }
     import io.grpc.netty.shaded.io.netty.handler.codec.http2.Http2SecurityUtil
     import io.grpc.netty.shaded.io.netty.handler.ssl.SupportedCipherSuiteFilter
+    val protocols: Array[String] = minimumTlsVersion match {
+      case Some(v) => SSLContextUtils.enabledProtocols(javaSslContext, v)
+      case None    => null // use JDK defaults (null is accepted as indicated in constructor Javadoc)
+    }
     // See
     // https://github.com/netty/netty/blob/4.1/handler/src/main/java/io/netty/handler/ssl/JdkSslContext.java#L229-L309
     new JdkSslContext(
@@ -211,7 +241,7 @@ object NettyClientUtils {
         ApplicationProtocolConfig.SelectedListenerFailureBehavior.ACCEPT,
         "h2"),
       ClientAuth.NONE, // server-only option, which is ignored as isClient=true (as indicated in constructor Javadoc)
-      /* String[] protocols */ null, // use JDK defaults (null is accepted as indicated in constructor Javadoc)
+      protocols,
       /* boolean startTls */ false)
   }
 

--- a/runtime/src/main/scala/org/apache/pekko/grpc/internal/PekkoHttpClientUtils.scala
+++ b/runtime/src/main/scala/org/apache/pekko/grpc/internal/PekkoHttpClientUtils.scala
@@ -23,7 +23,7 @@ import pekko.actor.ClassicActorSystemProvider
 import pekko.annotation.InternalApi
 import pekko.event.LoggingAdapter
 import pekko.grpc.GrpcProtocol.GrpcProtocolReader
-import pekko.grpc.{ GrpcClientSettings, GrpcResponseMetadata, GrpcSingleResponse, ProtobufSerializer }
+import pekko.grpc.{ GrpcClientSettings, GrpcResponseMetadata, GrpcSingleResponse, ProtobufSerializer, SSLContextUtils }
 import pekko.http.scaladsl.model.HttpEntity.{ Chunk, Chunked, LastChunk, Strict }
 import pekko.http.scaladsl.{ ClientTransport, ConnectionContext, Http }
 import pekko.http.scaladsl.model._
@@ -94,18 +94,19 @@ object PekkoHttpClientUtils {
 
     val http2client =
       if (settings.useTls) {
-        val connectionContext =
-          ConnectionContext.httpsClient {
-            settings.sslContext.getOrElse {
-              settings.trustManager match {
-                case None               => SSLContext.getDefault
-                case Some(trustManager) =>
-                  val sslContext: SSLContext = SSLContext.getInstance("TLS")
-                  sslContext.init(Array[KeyManager](), Array[TrustManager](trustManager), new SecureRandom)
-                  sslContext
-              }
+        val baseContext =
+          settings.sslContext.getOrElse {
+            settings.trustManager match {
+              case None               => SSLContext.getDefault
+              case Some(trustManager) =>
+                val sslContext: SSLContext = SSLContext.getInstance("TLS")
+                sslContext.init(Array[KeyManager](), Array[TrustManager](trustManager), new SecureRandom)
+                sslContext
             }
           }
+        val sslContext = settings.minimumTlsVersion.fold(baseContext)(v =>
+          SSLContextUtils.withMinimumTlsVersion(baseContext, v))
+        val connectionContext = ConnectionContext.httpsClient(sslContext)
 
         builder.withCustomHttpsConnectionContext(connectionContext).managedPersistentHttp2()
       } else {

--- a/runtime/src/main/scala/org/apache/pekko/grpc/internal/PekkoHttpClientUtils.scala
+++ b/runtime/src/main/scala/org/apache/pekko/grpc/internal/PekkoHttpClientUtils.scala
@@ -24,7 +24,7 @@ import pekko.annotation.InternalApi
 import pekko.event.LoggingAdapter
 import pekko.grpc.GrpcProtocol.GrpcProtocolReader
 import pekko.grpc.scaladsl.headers.PercentEncoding
-import pekko.grpc.{ GrpcClientSettings, GrpcResponseMetadata, GrpcSingleResponse, ProtobufSerializer }
+import pekko.grpc.{ GrpcClientSettings, GrpcResponseMetadata, GrpcSingleResponse, ProtobufSerializer, SSLContextUtils }
 import pekko.http.scaladsl.model.HttpEntity.{ Chunk, Chunked, LastChunk, Strict }
 import pekko.http.scaladsl.{ ClientTransport, ConnectionContext, Http, HttpsConnectionContext }
 import pekko.http.scaladsl.model._
@@ -228,10 +228,15 @@ object PekkoHttpClientUtils {
    *
    * The `SSLContext` to use for the pekko-http backend, from the explicitly configured context,
    * the configured trust manager, or the JVM default.
+   *
+   * When `minimum-tls-version` is set the context is wrapped so that every `SSLEngine` it
+   * creates enables only protocols at or above that version. Applying it here rather than at
+   * one of the call sites means both the verifying and the `verify-hostname = false`
+   * connection contexts inherit the floor.
    */
   @InternalApi
-  private[grpc] def sslContextFor(settings: GrpcClientSettings): SSLContext =
-    settings.sslContext.getOrElse {
+  private[grpc] def sslContextFor(settings: GrpcClientSettings): SSLContext = {
+    val base = settings.sslContext.getOrElse {
       settings.trustManager match {
         case None               => SSLContext.getDefault
         case Some(trustManager) =>
@@ -240,6 +245,8 @@ object PekkoHttpClientUtils {
           ctx
       }
     }
+    settings.minimumTlsVersion.fold(base)(SSLContextUtils.withMinimumTlsVersion(base, _))
+  }
 
   /**
    * INTERNAL API

--- a/runtime/src/test/scala/org/apache/pekko/grpc/internal/MinimumTlsVersionSpec.scala
+++ b/runtime/src/test/scala/org/apache/pekko/grpc/internal/MinimumTlsVersionSpec.scala
@@ -1,0 +1,337 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.pekko.grpc.internal
+
+import java.nio.charset.StandardCharsets.UTF_8
+import java.security.{ KeyFactory, KeyStore, SecureRandom }
+import java.security.cert.CertificateFactory
+import java.security.spec.PKCS8EncodedKeySpec
+import java.util.Base64
+
+import javax.net.ssl.{ KeyManagerFactory, SSLContext, SSLEngine, SSLHandshakeException }
+
+import scala.concurrent.Future
+import scala.concurrent.duration._
+import scala.util.{ Failure, Success, Try }
+
+import com.typesafe.config.ConfigFactory
+import io.grpc.netty.shaded.io.netty.buffer.ByteBufAllocator
+import org.apache.pekko
+import pekko.actor.ActorSystem
+import pekko.grpc.{ GrpcClientSettings, SSLContextUtils }
+import pekko.http.scaladsl.{ ConnectionContext, Http }
+import pekko.http.scaladsl.model.{ HttpRequest, HttpResponse, StatusCodes }
+import pekko.stream.scaladsl.{ Sink, Source }
+import pekko.testkit.TestKit
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.time.Span
+import org.scalatest.wordspec.AnyWordSpecLike
+
+/**
+ * Covers `minimum-tls-version` end to end: the protocol filtering itself, the `SSLContext`
+ * wrapper built from it, that the floor reaches the pekko-http connection context on both the
+ * verifying and the opt-out path, and that a floor above what the server offers actually
+ * fails the handshake.
+ */
+class MinimumTlsVersionSpec
+    extends TestKit(ActorSystem())
+    with AnyWordSpecLike
+    with Matchers
+    with ScalaFutures
+    with BeforeAndAfterAll {
+
+  implicit val patience: PatienceConfig =
+    PatienceConfig(10.seconds, Span(100, org.scalatest.time.Millis))
+
+  private def resourceBytes(path: String): Array[Byte] = {
+    val in = getClass.getResourceAsStream(path)
+    try in.readAllBytes()
+    finally in.close()
+  }
+
+  private def serverSslContext(): SSLContext = {
+    val cert = CertificateFactory
+      .getInstance("X.509")
+      .generateCertificate(getClass.getResourceAsStream("/certs/localhost-server.crt"))
+    val pem = new String(resourceBytes("/certs/localhost-server.key"), UTF_8)
+      .replace("-----BEGIN PRIVATE KEY-----", "")
+      .replace("-----END PRIVATE KEY-----", "")
+      .replaceAll("\\s", "")
+    val key = KeyFactory.getInstance("RSA").generatePrivate(new PKCS8EncodedKeySpec(Base64.getDecoder.decode(pem)))
+
+    val keyStore = KeyStore.getInstance("PKCS12")
+    keyStore.load(null, null)
+    keyStore.setKeyEntry("server", key, Array.emptyCharArray, Array(cert))
+    val kmf = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm)
+    kmf.init(keyStore, Array.emptyCharArray)
+
+    val ctx = SSLContext.getInstance("TLS")
+    ctx.init(kmf.getKeyManagers, null, new SecureRandom)
+    ctx
+  }
+
+  /** A server that will only ever negotiate TLSv1.2. */
+  private val binding = {
+    val ctx = serverSslContext()
+    val engineCreator = () => {
+      val engine: SSLEngine = ctx.createSSLEngine()
+      engine.setUseClientMode(false)
+      engine.setEnabledProtocols(Array("TLSv1.2"))
+      engine
+    }
+    Http()
+      .newServerAt("127.0.0.1", 0)
+      .enableHttps(ConnectionContext.httpsServer(engineCreator))
+      .bind(_ => Future.successful(HttpResponse(StatusCodes.OK)))
+      .futureValue
+  }
+
+  private def settingsFor(minimumTlsVersion: Option[String]): GrpcClientSettings = {
+    val base = GrpcClientSettings
+      .connectToServiceAt("localhost", binding.localAddress.getPort)
+      .withTrustManager(SSLContextUtils.trustManagerFromResource("/certs/rootCA.crt"))
+    minimumTlsVersion.fold(base)(base.withMinimumTlsVersion)
+  }
+
+  /**
+   * The TLS versions an engine will negotiate.
+   *
+   * Netty additionally enables `SSLv2Hello`, which is a ClientHello wire format rather than a
+   * protocol that can be negotiated, so it says nothing about the version floor.
+   */
+  private def tlsVersionsOf(engine: SSLEngine): Seq[String] =
+    engine.getEnabledProtocols.toSeq.filterNot(_ == "SSLv2Hello")
+
+  /** Runs a real TLS handshake through the connection context our client code builds. */
+  private def handshake(minimumTlsVersion: Option[String]): Try[HttpResponse] = {
+    val context = PekkoHttpClientUtils.connectionContext(settingsFor(minimumTlsVersion), system.log)
+    val connection = Http().outgoingConnectionHttps("localhost", binding.localAddress.getPort, context)
+    Try(Source.single(HttpRequest(uri = "/")).via(connection).runWith(Sink.head).futureValue)
+  }
+
+  /** Settings built from the `"*"` client defaults, with `overrides` layered on top. */
+  private def settingsFromConfig(overrides: String): GrpcClientSettings = {
+    val clientConfig = ConfigFactory
+      .parseString(s"""host = "example.com"
+                      |port = 443
+                      |$overrides""".stripMargin)
+      .withFallback(ConfigFactory.load().getConfig("""pekko.grpc.client."*""""))
+    GrpcClientSettings.fromConfig(clientConfig)(system)
+  }
+
+  "SSLContextUtils.enabledProtocols" should {
+
+    "keep every known version at or above the floor" in {
+      SSLContextUtils.enabledProtocols(SSLContext.getDefault, "TLSv1.2").toSet shouldBe
+      Set("TLSv1.2", "TLSv1.3")
+    }
+
+    "drop versions below the floor" in {
+      SSLContextUtils.enabledProtocols(SSLContext.getDefault, "TLSv1.3").toSet shouldBe Set("TLSv1.3")
+    }
+
+    "never widen to a version below TLSv1.2, even though it reads the supported set" in {
+      // It reads getSupportedSSLParameters rather than getDefaultSSLParameters, so that a
+      // version the JDK supports but does not enable by default stays reachable. That is not
+      // observable on a JDK whose default set is already TLSv1.2 + TLSv1.3, but the widening
+      // it allows must never reach below the floor: the supported set also carries TLSv1.1,
+      // TLSv1, SSLv3 and SSLv2Hello, and the known-version list is what keeps those out.
+      val supported = SSLContext.getDefault.getSupportedSSLParameters.getProtocols.toSet
+      withClue(s"supported: ${supported.mkString(", ")}") {
+        supported should contain("TLSv1.1")
+      }
+      SSLContextUtils.enabledProtocols(SSLContext.getDefault, "TLSv1.2").toSet shouldBe
+      Set("TLSv1.2", "TLSv1.3")
+    }
+
+    "reject a version it does not know" in {
+      val e = intercept[IllegalArgumentException] {
+        SSLContextUtils.enabledProtocols(SSLContext.getDefault, "TLSv1.1")
+      }
+      e.getMessage should include("Unknown TLS version 'TLSv1.1'")
+    }
+
+    "filter a caller-supplied protocol list" in {
+      SSLContextUtils
+        .enabledProtocols(Array("SSLv3", "TLSv1", "TLSv1.1", "TLSv1.2", "TLSv1.3"), "TLSv1.3")
+        .toSeq shouldBe Seq("TLSv1.3")
+    }
+
+    "fail when nothing survives the floor" in {
+      intercept[IllegalStateException] {
+        SSLContextUtils.enabledProtocols(Array("TLSv1", "TLSv1.1"), "TLSv1.2")
+      }
+    }
+  }
+
+  "SSLContextUtils.withMinimumTlsVersion" should {
+
+    "constrain engines created without a peer" in {
+      val ctx = SSLContextUtils.withMinimumTlsVersion(SSLContext.getDefault, "TLSv1.3")
+
+      ctx.createSSLEngine().getEnabledProtocols.toSeq shouldBe Seq("TLSv1.3")
+    }
+
+    "constrain engines created for a peer, which is the one gRPC uses" in {
+      val ctx = SSLContextUtils.withMinimumTlsVersion(SSLContext.getDefault, "TLSv1.3")
+
+      ctx.createSSLEngine("example.com", 443).getEnabledProtocols.toSeq shouldBe Seq("TLSv1.3")
+    }
+
+    "survive the engine reconfiguration pekko-http performs on top of it" in {
+      // ConnectionContext.httpsClient(SSLContext) sets client mode and the endpoint
+      // identification algorithm through setSSLParameters, which could have reset protocols
+      val ctx = SSLContextUtils.withMinimumTlsVersion(SSLContext.getDefault, "TLSv1.3")
+      val engine = ctx.createSSLEngine("example.com", 443)
+      engine.setUseClientMode(true)
+      val params = engine.getSSLParameters
+      params.setEndpointIdentificationAlgorithm("https")
+      engine.setSSLParameters(params)
+
+      engine.getEnabledProtocols.toSeq shouldBe Seq("TLSv1.3")
+      engine.getSSLParameters.getEndpointIdentificationAlgorithm shouldBe "https"
+    }
+  }
+
+  "The pekko-http client SSLContext" should {
+
+    "be unconstrained when no floor is configured" in {
+      val ctx = PekkoHttpClientUtils.sslContextFor(settingsFor(None))
+
+      ctx.createSSLEngine("example.com", 443).getEnabledProtocols should contain("TLSv1.2")
+    }
+
+    "carry the floor when one is configured" in {
+      val ctx = PekkoHttpClientUtils.sslContextFor(settingsFor(Some("TLSv1.3")))
+
+      ctx.createSSLEngine("example.com", 443).getEnabledProtocols.toSeq shouldBe Seq("TLSv1.3")
+    }
+
+    "carry the floor on the verify-hostname = false path too" in {
+      // the floor lives in sslContextFor, so it has to reach the engine the opt-out builds
+      val settings = settingsFor(Some("TLSv1.3")).withVerifyHostname(false)
+      val engine =
+        PekkoHttpClientUtils.insecureSslEngineCreator(PekkoHttpClientUtils.sslContextFor(settings))("h", 1)
+
+      engine.getEnabledProtocols.toSeq shouldBe Seq("TLSv1.3")
+    }
+  }
+
+  "A client with a minimum TLS version" should {
+
+    "complete the handshake when the server offers a version at the floor" in {
+      handshake(Some("TLSv1.2")) match {
+        case Success(response) => response.status shouldBe StatusCodes.OK
+        case Failure(e)        => fail(s"expected the handshake to succeed, got [$e]")
+      }
+    }
+
+    "fail the handshake when the server offers nothing at or above the floor" in {
+      // the server above only enables TLSv1.2, so requiring TLSv1.3 leaves no common version.
+      // This is the guard: without the floor applied the handshake below succeeds on TLSv1.2.
+      handshake(Some("TLSv1.3")) match {
+        case Success(response) => fail(s"expected the handshake to fail, got [$response]")
+        case Failure(e)        =>
+          val causes = Iterator.iterate(e: Throwable)(_.getCause).takeWhile(_ ne null).toList
+          withClue(causes.mkString(", ")) {
+            causes.exists(_.isInstanceOf[SSLHandshakeException]) shouldBe true
+          }
+      }
+    }
+
+    "connect over TLSv1.2 when no floor is configured" in {
+      handshake(None) match {
+        case Success(response) => response.status shouldBe StatusCodes.OK
+        case Failure(e)        => fail(s"expected the handshake to succeed, got [$e]")
+      }
+    }
+  }
+
+  "The netty client SslContext" should {
+
+    "not be built when nothing beyond the defaults is configured" in {
+      // grpc-java supplies its own client context in that case
+      NettyClientUtils.nettySslContext(settingsFromConfig("")) shouldBe None
+    }
+
+    "be built from the floor alone, with otherwise stock trust settings" in {
+      // the regression guard: this used to fall into a `case (None, None) => builder` branch
+      // that returned before minimum-tls-version was ever consulted, so the setting was
+      // silently ignored on the default backend in its most common configuration
+      val settings = settingsFromConfig("""minimum-tls-version = "TLSv1.3"""")
+      val sslContext = NettyClientUtils.nettySslContext(settings)
+
+      withClue("no SslContext was built, so the floor cannot have been applied: ") {
+        sslContext shouldBe defined
+      }
+      val engine = sslContext.get.newEngine(ByteBufAllocator.DEFAULT, "example.com", 443)
+      tlsVersionsOf(engine) shouldBe Seq("TLSv1.3")
+    }
+
+    "carry the floor alongside a trust manager" in {
+      val settings = settingsFor(Some("TLSv1.3"))
+      val engine =
+        NettyClientUtils.nettySslContext(settings).get.newEngine(ByteBufAllocator.DEFAULT, "example.com", 443)
+
+      tlsVersionsOf(engine) shouldBe Seq("TLSv1.3")
+    }
+
+    "leave protocols to the JDK when no floor is configured" in {
+      val engine =
+        NettyClientUtils.nettySslContext(settingsFor(None)).get.newEngine(ByteBufAllocator.DEFAULT, "example.com", 443)
+
+      tlsVersionsOf(engine) should contain("TLSv1.2")
+    }
+  }
+
+  "GrpcClientSettings" should {
+
+    "leave the floor unset by default" in {
+      settingsFromConfig("").minimumTlsVersion shouldBe None
+    }
+
+    "read the floor from configuration" in {
+      settingsFromConfig("""minimum-tls-version = "TLSv1.3"""").minimumTlsVersion shouldBe Some("TLSv1.3")
+    }
+
+    "expose the floor with otherwise stock TLS settings" in {
+      // the netty backend used to skip the setting entirely in exactly this shape, because
+      // no trust manager and no ssl-provider meant it never looked at minimumTlsVersion
+      val settings = settingsFromConfig("""minimum-tls-version = "TLSv1.3"""")
+
+      settings.minimumTlsVersion shouldBe Some("TLSv1.3")
+      settings.trustManager shouldBe None
+      settings.sslProvider shouldBe None
+      settings.sslContext shouldBe None
+    }
+
+    "keep the floor through withMinimumTlsVersion" in {
+      GrpcClientSettings
+        .connectToServiceAt("example.com", 443)
+        .withMinimumTlsVersion("TLSv1.3")
+        .minimumTlsVersion shouldBe Some("TLSv1.3")
+    }
+  }
+
+  override def afterAll(): Unit = {
+    binding.terminate(5.seconds).futureValue
+    super.afterAll()
+  }
+}


### PR DESCRIPTION
### Motivation

A TLS client should be able to require a protocol floor. Neither backend offered
one: the netty backend takes whatever `GrpcSslContexts` configures, and the
pekko-http backend takes whatever `SSLContext.getDefault` enables. On Java 17
both already mean TLSv1.2+, so this is not a fix for a weak default — it is the
knob for an operator who needs to *require* TLSv1.3, which no default provides.

### Modification

**Setting** — `minimum-tls-version` under `pekko.grpc.client."*"`, plus
`GrpcClientSettings.withMinimumTlsVersion`. Empty by default, which
`getOptionalString` maps to `None`, meaning "use whatever the JDK enables".
Accepted values are `""`, `"TLSv1.2"` and `"TLSv1.3"`; anything else is rejected
with `IllegalArgumentException` naming the known versions.

**Protocol filtering** — `SSLContextUtils.enabledProtocols` returns the versions
at or above the floor. It reads `getSupportedSSLParameters` rather than
`getDefaultSSLParameters`, so a version the JDK supports but does not enable by
default stays reachable; `TlsVersionOrder` bounds the result to TLSv1.2 and
TLSv1.3, so reading the wider set cannot re-enable TLSv1.1 or SSLv3. When
nothing survives the floor it throws `IllegalStateException` rather than
returning an empty list that would fail obscurely later.

**pekko-http backend** — the floor is applied in `sslContextFor`, so both the
verifying connection context and the `verify-hostname = false` opt-out added by
 #857 inherit it. `withMinimumTlsVersion` wraps the `SSLContext` so every engine
it creates is constrained; the constraint survives the `setSSLParameters` call
pekko-http makes to set client mode and endpoint identification.

**netty backend** — `nettySslContext` was extracted from `createChannel` and now
decides on `minimumTlsVersion` alongside the trust manager and provider. It has
to: with stock trust settings the floor is the only reason to build a context at
all, and leaving it out of the match meant the setting was silently ignored on
the default backend in its most common configuration. Only the all-empty case
still defers to grpc-java's own client context.

### Result

A configured floor reaches both backends on every TLS path, including netty with
default trust settings. The default is unchanged behaviour.

### Tests

`MinimumTlsVersionSpec` — 23 tests covering the protocol filtering, the
`SSLContext` wrapper, both backends, and the settings plumbing. The handshake
cases run real TLS against a local server whose engine enables only TLSv1.2, so
requiring TLSv1.3 leaves no common version and fails for that reason and nothing
else.

Confirmed the guards bite, by reverting each fix in turn:

- floor not applied in `sslContextFor` → 3 fail, including the handshake case
- netty `case (None, None, _)` hole restored → the stock-trust-settings case fails

The switch to `getSupportedSSLParameters` is deliberately not asserted on: it is
not observable on a JDK whose default set is already TLSv1.2 + TLSv1.3. The test
pins what must hold either way — that filtering never reaches below the floor —
and says so in a comment.

- `sbt "runtime/testOnly org.apache.pekko.grpc.internal.MinimumTlsVersionSpec"` — 23 passed
- `sbt "runtime/compile"` — passed
- `sbt "runtime/mimaReportBinaryIssues"` — passed
- `sbt scalafmtAll scalafmtSbt` — applied
- `sbt "runtime/test"` (full suite) — not run locally, left to CI

### Notes

Rebased onto `main`; was based on `fbefc10d`, roughly 33 commits back, and
predates the hostname-verification work in #857.

One known gap, left as is: `withMinimumTlsVersion` wraps `SSLContextSpi` and
constrains the engine factories, but `engineGetSocketFactory` delegates
unwrapped, so sockets obtained from it are not constrained. gRPC never takes
that path — both backends go through `createSSLEngine` — so it is latent rather
than live, but the wrapper looks total and is not.

### References

Refs #857
