### PR TITLE
tidy up close logic

### DIFF
--- a/runtime/src/main/scala/org/apache/pekko/grpc/GrpcChannel.scala
+++ b/runtime/src/main/scala/org/apache/pekko/grpc/GrpcChannel.scala
@@ -48,8 +48,8 @@ final class GrpcChannel private (
    * Scala API: Initiates a shutdown in which preexisting and new calls are cancelled.
    */
   def close(): Future[pekko.Done] = {
-    Grpc(sys).deregisterChannel(this)
-    ChannelUtils.close(internalChannel)
+    try ChannelUtils.close(internalChannel)
+    finally Grpc(sys).deregisterChannel(this)
   }
 
   /**

--- a/runtime/src/main/scala/org/apache/pekko/grpc/internal/PekkoNettyGrpcClientGraphStage.scala
+++ b/runtime/src/main/scala/org/apache/pekko/grpc/internal/PekkoNettyGrpcClientGraphStage.scala
@@ -162,12 +162,11 @@ private final class PekkoNettyGrpcClientGraphStage[I, O](
           call.request(1)
           requested += 1
         }
-      override def onDownstreamFinish(cause: Throwable): Unit =
-        if (isClosed(out)) {
-          call.cancel("Downstream cancelled", cause)
-          call = null
-          completeStage()
-        }
+      override def onDownstreamFinish(cause: Throwable): Unit = {
+        if (call != null) call.cancel("Downstream cancelled", cause)
+        call = null
+        completeStage()
+      }
 
       def onCallClosed(status: Status, trailers: Metadata): Unit = {
         if (status.isOk()) {


### PR DESCRIPTION
Finding 26 — GrpcChannel.close(): Reversed to try close / finally deregister. The channel always gets closed even if deregistration throws. Order reversal is fine — closing the channel is the critical action, deregistration is cleanup.

Finding 27 — onDownstreamFinish: Removed the isClosed(out) guard. Now call.cancel and completeStage() always run when downstream finishes. The null check on call guards against double-cancel.