### PR TITLE
Override newWriter and newReader in GrpcProtocolNative

### DIFF
--- a/runtime/src/main/scala/org/apache/pekko/grpc/internal/GrpcProtocolNative.scala
+++ b/runtime/src/main/scala/org/apache/pekko/grpc/internal/GrpcProtocolNative.scala
@@ -46,6 +46,10 @@ object GrpcProtocolNative extends AbstractGrpcProtocol("grpc") {
   override protected def reader(codec: Codec): GrpcProtocolReader =
     AbstractGrpcProtocol.reader(codec, decodeFrame)
 
+  override def newWriter(codec: Codec): GrpcProtocolWriter = writer(codec)
+
+  override def newReader(codec: Codec): GrpcProtocolReader = reader(codec)
+
   @inline
   private def decodeFrame(@nowarn("msg=is never used") frameType: Int, data: ByteString) = DataFrame(data)
 


### PR DESCRIPTION
cherry-picked from https://github.com/akka/akka-grpc/pull/1787, which is now Apache 2.0.