### PR TITLE
Update grpc-core, grpc-interop-testing, ... to 1.83.1 (#817)

### DIFF
--- a/benchmark-java/build.sbt
+++ b/benchmark-java/build.sbt
@@ -14,7 +14,7 @@ run / javaOptions ++= List("-Xms1g", "-Xmx1g", "-XX:+PrintGCDetails", "-XX:+Prin
 // generate both client and server (default) in Java
 pekkoGrpcGeneratedLanguages := Seq(PekkoGrpc.Java)
 
-val grpcVersion = "1.75.0" // checked synced by VersionSyncCheckPlugin
+val grpcVersion = "1.83.1" // checked synced by VersionSyncCheckPlugin
 
 val runtimeProject = ProjectRef(file("../"), "runtime")
 

--- a/benchmark-java/project/build.properties
+++ b/benchmark-java/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.11.7
+sbt.version=1.12.14

--- a/build.sbt
+++ b/build.sbt
@@ -212,6 +212,11 @@ lazy val interopTests = Project(id = "interop-tests", base = file("interop-tests
     // We need to be able to publish locally in order for sbt interopt tests to work
     // however this sbt project should not be published to an actual repository
     publishLocal / skip := false,
+    // the following is needed to exclude the gRPC generated sources for protobuf-java from the sources,
+    // they cause tests to fail - https://github.com/apache/pekko-grpc/pull/610
+    Compile / sources := (Compile / sources).value.filterNot { f =>
+      f.getPath.replace('\\', '/').contains("/src_managed/main/com/google/protobuf")
+    },
     Compile / doc := (Compile / doc / target).value)
   .settings(inConfig(Test)(Seq(
     reStart / mainClass := (Test / run / mainClass).value, {

--- a/build.sbt
+++ b/build.sbt
@@ -182,7 +182,7 @@ lazy val sbtPlugin = Project(id = "sbt-plugin", base = file("sbt-plugin"))
       val p3 = (runtime / publishLocal).value
       val p4 = (interopTests / publishLocal).value
     },
-    scriptedSbt := "1.11.7",
+    scriptedSbt := "1.12.14",
     scriptedBufferLog := false)
   .settings(
     crossScalaVersions := Dependencies.Versions.CrossScalaForPlugin,

--- a/build.sbt
+++ b/build.sbt
@@ -72,6 +72,7 @@ lazy val codegen = Project(id = "codegen", base = file("codegen"))
     (assembly / assemblyOption) := (assembly / assemblyOption).value.withPrependShellScript(
       Some(sbtassembly.AssemblyPlugin.defaultUniversalScript(shebang = true))),
     (assembly / assemblyMergeStrategy) := {
+      case PathList("META-INF", "LICENSE")                          => MergeStrategy.concat
       case PathList("META-INF", "MANIFEST.MF")                      => MergeStrategy.discard
       case PathList("META-INF", "versions", _, "module-info.class") => MergeStrategy.discard
       case "LICENSE" | "LICENSE.txt" | "NOTICE"                     => MergeStrategy.discard

--- a/gradle-plugin/src/main/groovy/org/apache/pekko/grpc/gradle/PekkoGrpcPluginExtension.groovy
+++ b/gradle-plugin/src/main/groovy/org/apache/pekko/grpc/gradle/PekkoGrpcPluginExtension.groovy
@@ -18,7 +18,7 @@ class PekkoGrpcPluginExtension {
 
     static final String PROTOC_PLUGIN_SCALA_VERSION = "2.12"
 
-    static final String GRPC_VERSION = "1.75.0" // checked synced by VersionSyncCheckPlugin
+    static final String GRPC_VERSION = "1.83.1" // checked synced by VersionSyncCheckPlugin
 
     static final String PLUGIN_CODE = 'org.apache.pekko.grpc.gradle'
 

--- a/gradle-plugin/src/main/groovy/org/apache/pekko/grpc/gradle/PekkoGrpcPluginExtension.groovy
+++ b/gradle-plugin/src/main/groovy/org/apache/pekko/grpc/gradle/PekkoGrpcPluginExtension.groovy
@@ -14,7 +14,7 @@ import org.gradle.api.Project
 
 class PekkoGrpcPluginExtension {
 
-    static final String PROTOC_VERSION = "3.25.8" // checked synced by VersionSyncCheckPlugin
+    static final String PROTOC_VERSION = "3.25.9" // checked synced by VersionSyncCheckPlugin
 
     static final String PROTOC_PLUGIN_SCALA_VERSION = "2.12"
 

--- a/maven-plugin/src/main/maven/plugin.xml
+++ b/maven-plugin/src/main/maven/plugin.xml
@@ -95,7 +95,7 @@
         <extraGenerators implementation="java.util.List" default-value=""/>
         <protoPaths default-value="${project.basedir}/src/main/proto,${project.basedir}/src/main/protobuf">${pekko-grpc.protoPaths}</protoPaths>
         <outputDirectory default-value="${project.build.directory}/generated-sources">${pekko-grpc.outputDirectory}</outputDirectory>
-	<protocVersion implementation="java.lang.String" default-value="-v3.25.8">${pekko-grpc.protoc-version}</protocVersion> <!-- checked synced by VersionSyncCheckPlugin -->
+	<protocVersion implementation="java.lang.String" default-value="-v3.25.9">${pekko-grpc.protoc-version}</protocVersion> <!-- checked synced by VersionSyncCheckPlugin -->
         <includeStdTypes implementation="boolean" default-value="false" />
       </configuration>
     </mojo>
@@ -187,7 +187,7 @@
         <extraGenerators implementation="java.util.List" default-value=""/>
         <protoPaths default-value="src/test/proto,src/test/protobuf">${pekko-grpc.protoPaths}</protoPaths>
         <outputDirectory default-value="target/generated-test-sources">${pekko-grpc.outputDirectory}</outputDirectory>
-        <protocVersion implementation="java.lang.String" default-value="-v3.25.8">${pekko-grpc.protoc-version}</protocVersion> <!-- checked synced by VersionSyncCheckPlugin -->
+        <protocVersion implementation="java.lang.String" default-value="-v3.25.9">${pekko-grpc.protoc-version}</protocVersion> <!-- checked synced by VersionSyncCheckPlugin -->
         <includeStdTypes implementation="boolean" default-value="false" />
       </configuration>
     </mojo>

--- a/plugin-tester-java/pom.xml
+++ b/plugin-tester-java/pom.xml
@@ -25,7 +25,7 @@
     <maven-dependency-plugin.version>3.8.1</maven-dependency-plugin.version>
     <maven-exec-plugin.version>3.5.1</maven-exec-plugin.version>
     <pekko.http.version>1.2.0</pekko.http.version>
-    <grpc.version>1.75.0</grpc.version> <!-- checked synced by VersionSyncCheckPlugin -->
+    <grpc.version>1.83.1</grpc.version> <!-- checked synced by VersionSyncCheckPlugin -->
     <project.encoding>UTF-8</project.encoding>
   </properties>
 

--- a/plugin-tester-scala/pom.xml
+++ b/plugin-tester-scala/pom.xml
@@ -24,7 +24,7 @@
     <maven.compiler.target>1.8</maven.compiler.target>
     <pekko.version>1.1.5</pekko.version>
     <pekko.http.version>1.2.0</pekko.http.version>
-    <grpc.version>1.75.0</grpc.version> <!-- checked synced by VersionSyncCheckPlugin -->
+    <grpc.version>1.83.1</grpc.version> <!-- checked synced by VersionSyncCheckPlugin -->
     <project.encoding>UTF-8</project.encoding>
   </properties>
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -32,7 +32,7 @@ object Dependencies {
     val pekkoHttp = PekkoHttpDependency.version
     val pekkoHttpBinary = pekkoHttp.take(3)
 
-    val grpc = "1.75.0" // checked synced by VersionSyncCheckPlugin
+    val grpc = "1.83.1" // checked synced by VersionSyncCheckPlugin
     // Even referenced explicitly in the sbt-plugin's sbt-tests
     // If changing this, remember to update protoc plugin version to align in
     // maven-plugin/src/main/maven/plugin.xml and org.apache.pekko.grpc.sbt.PekkoGrpcPlugin

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -59,6 +59,7 @@ object Dependencies {
     val grpcInteropTesting = ("io.grpc" % "grpc-interop-testing" % Versions.grpc)
       .exclude("io.grpc", "grpc-alts")
       .exclude("io.grpc", "grpc-xds")
+      .exclude("io.opentelemetry", "opentelemetry-exporter-prometheus")
 
     val slf4jApi = "org.slf4j" % "slf4j-api" % "2.0.17"
     val mavenPluginApi = "org.apache.maven" % "maven-plugin-api" % Versions.maven

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -36,8 +36,8 @@ object Dependencies {
     // Even referenced explicitly in the sbt-plugin's sbt-tests
     // If changing this, remember to update protoc plugin version to align in
     // maven-plugin/src/main/maven/plugin.xml and org.apache.pekko.grpc.sbt.PekkoGrpcPlugin
-    val googleProtoc = "3.25.8" // checked synced by VersionSyncCheckPlugin
-    val googleProtobufJava = "3.25.8"
+    val googleProtoc = "3.25.9" // checked synced by VersionSyncCheckPlugin
+    val googleProtobufJava = "3.25.9"
 
     val scalaTest = "3.2.19"
 

--- a/sbt-plugin/src/sbt-test/gen-scala-server/00-interop/build.sbt
+++ b/sbt-plugin/src/sbt-test/gen-scala-server/00-interop/build.sbt
@@ -11,7 +11,7 @@ scalaVersion := "2.12.21"
 
 organization := "org.apache.pekko"
 
-val grpcVersion = "1.75.0" // checked synced by VersionSyncCheckPlugin
+val grpcVersion = "1.83.1" // checked synced by VersionSyncCheckPlugin
 
 libraryDependencies ++= Seq(
   "io.grpc" % "grpc-interop-testing" % grpcVersion % "protobuf-src",


### PR DESCRIPTION
cherry pick fbefc10d7a1061b23b49252b289ac68d8cc675d7 #817

I had to copy a few build changes from the main branch to fix build issues.
I updated protobuf-java to 3.25.9 from 3.25.8. We support protobuf-java 4.x in 2.0.0 releases.