### PR TITLE
Fix Codecs.negotiate() dropping supported encodings with whitespace

### DIFF
--- a/runtime/src/main/scala/org/apache/pekko/grpc/scaladsl/headers/headers.scala
+++ b/runtime/src/main/scala/org/apache/pekko/grpc/scaladsl/headers/headers.scala
@@ -44,7 +44,7 @@ object `Message-Accept-Encoding` extends ModeledCustomHeaderCompanion[`Message-A
     Try(new `Message-Accept-Encoding`(value))
 
   def findIn(headers: Iterable[jm.HttpHeader]): Array[String] =
-    headers.collectFirst { case h if h.is(name) => h.value().split(',') }.getOrElse(Array.empty)
+    headers.collectFirst { case h if h.is(name) => h.value().split(',').map(_.trim) }.getOrElse(Array.empty)
 
   /** Java API */
   def findIn(headers: java.lang.Iterable[jm.HttpHeader]): Array[String] = {

--- a/runtime/src/test/scala/org/apache/pekko/grpc/CodecsSpec.scala
+++ b/runtime/src/test/scala/org/apache/pekko/grpc/CodecsSpec.scala
@@ -72,6 +72,11 @@ class CodecsSpec extends AnyWordSpec with Matchers with TryValues {
       Codecs.negotiate(request) should be(Gzip)
     }
 
+    "negotiate gzip when grpc-accept-encoding uses comma+space separators (as sent by grpc-go/grpc-python/grpcurl)" in {
+      val request = HttpRequest(headers = immutable.Seq(RawHeader("grpc-accept-encoding", "deflate, gzip")))
+      Codecs.negotiate(request) should be(Gzip)
+    }
+
   }
 
   "Detecting message encoding from remote" should {


### PR DESCRIPTION
Motivation:
grpc-accept-encoding headers formatted with a space after the comma (e.g. "deflate, gzip", as sent by grpc-go/grpc-python/grpcurl) were never matched against supported codec names, silently downgrading negotiation to Identity even when the client offered gzip.

Modification:
Trim each split token in `Message-Accept-Encoding`.findIn before codec-name lookup.

Result:
Codecs.negotiate now correctly picks a supported codec regardless of whitespace around commas in grpc-accept-encoding.

Tests:
- sbt "runtime / testOnly org.apache.pekko.grpc.CodecsSpec" - pass

References:
Fixes #847