### PR TITLE
Fix Codecs.negotiate() dropping supported encodings with whitespace

### DIFF
--- a/runtime/src/main/scala/org/apache/pekko/grpc/scaladsl/headers/headers.scala
+++ b/runtime/src/main/scala/org/apache/pekko/grpc/scaladsl/headers/headers.scala
@@ -23,6 +23,14 @@ import scala.collection.compat.immutable.ArraySeq
 import scala.collection.immutable
 import scala.util.Try
 
+/**
+ * Simple CSV parser for HTTP header values. Not meant to be a full CSV parser,
+ * just enough to parse the headers we care about.
+ */
+private object SimpleCSVParser {
+  def parse(value: String): Array[String] = value.split(',').map(_.trim)
+}
+
 @ApiMayChange
 final class `Message-Accept-Encoding`(override val value: String)
     extends ModeledCustomHeader[`Message-Accept-Encoding`] {
@@ -30,7 +38,7 @@ final class `Message-Accept-Encoding`(override val value: String)
   override def renderInResponses = true
   override val companion = `Message-Accept-Encoding`
 
-  lazy val values: Array[String] = value.split(',')
+  lazy val values: Array[String] = SimpleCSVParser.parse(value)
 }
 
 @ApiMayChange
@@ -42,7 +50,9 @@ object `Message-Accept-Encoding` extends ModeledCustomHeaderCompanion[`Message-A
     Try(new `Message-Accept-Encoding`(value))
 
   def findIn(headers: Iterable[jm.HttpHeader]): Array[String] =
-    headers.collectFirst { case h if h.is(name) => h.value().split(',').map(_.trim) }.getOrElse(Array.empty)
+    headers.collectFirst {
+      case h if h.is(name) => SimpleCSVParser.parse(h.value())
+    }.getOrElse(Array.empty)
 
   /** Java API */
   def findIn(headers: java.lang.Iterable[jm.HttpHeader]): Array[String] = {
@@ -131,10 +141,11 @@ private[grpc] object `Trailer` extends ModeledCustomHeaderCompanion[`Trailer`] {
 
   override val lowercaseName: String = super.lowercaseName
 
-  override def parse(value: String): Try[`Trailer`] = Try(`Trailer`(ArraySeq.unsafeWrapArray(value.split(','))))
+  override def parse(value: String): Try[`Trailer`] =
+    Try(`Trailer`(ArraySeq.unsafeWrapArray(SimpleCSVParser.parse(value))))
 
   def findIn(headers: immutable.Seq[HttpHeader]): Option[immutable.Seq[String]] =
     headers.collectFirst {
-      case header if header.is(name) => ArraySeq.unsafeWrapArray(header.value().split(',').map(_.trim))
+      case header if header.is(name) => ArraySeq.unsafeWrapArray(SimpleCSVParser.parse(header.value()))
     }
 }

--- a/runtime/src/main/scala/org/apache/pekko/grpc/scaladsl/headers/headers.scala
+++ b/runtime/src/main/scala/org/apache/pekko/grpc/scaladsl/headers/headers.scala
@@ -42,7 +42,7 @@ object `Message-Accept-Encoding` extends ModeledCustomHeaderCompanion[`Message-A
     Try(new `Message-Accept-Encoding`(value))
 
   def findIn(headers: Iterable[jm.HttpHeader]): Array[String] =
-    headers.collectFirst { case h if h.is(name) => h.value().split(',') }.getOrElse(Array.empty)
+    headers.collectFirst { case h if h.is(name) => h.value().split(',').map(_.trim) }.getOrElse(Array.empty)
 
   /** Java API */
   def findIn(headers: java.lang.Iterable[jm.HttpHeader]): Array[String] = {

--- a/runtime/src/test/scala/org/apache/pekko/grpc/CodecsSpec.scala
+++ b/runtime/src/test/scala/org/apache/pekko/grpc/CodecsSpec.scala
@@ -16,6 +16,7 @@ import org.apache.pekko
 import pekko.grpc.internal.{ Codecs, Gzip, Identity }
 import pekko.grpc.scaladsl.headers
 import pekko.http.scaladsl.model.HttpRequest
+import pekko.http.scaladsl.model.headers.RawHeader
 import io.grpc.Status
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec

--- a/runtime/src/test/scala/org/apache/pekko/grpc/CodecsSpec.scala
+++ b/runtime/src/test/scala/org/apache/pekko/grpc/CodecsSpec.scala
@@ -58,6 +58,24 @@ class CodecsSpec extends AnyWordSpec with Matchers with TryValues {
       Codecs.negotiate(accept("xxxxx")) should be(Identity)
     }
 
+    // Regression test: akka-grpc #1897 — request.header[T] silently returns None for
+    // ModeledCustomHeader types, which would break compression negotiation.
+    // Our implementation uses findIn on raw headers instead, which works correctly.
+    "negotiate gzip from raw headers (not typed custom headers)" in {
+      val request = HttpRequest(headers = immutable.Seq(RawHeader("grpc-accept-encoding", "gzip")))
+      Codecs.negotiate(request) should be(Gzip)
+    }
+
+    "negotiate from raw headers with multiple encodings" in {
+      val request = HttpRequest(headers = immutable.Seq(RawHeader("grpc-accept-encoding", "gzip,identity")))
+      Codecs.negotiate(request) should be(Gzip)
+    }
+
+    "negotiate gzip when grpc-accept-encoding uses comma+space separators (as sent by grpc-go/grpc-python/grpcurl)" in {
+      val request = HttpRequest(headers = immutable.Seq(RawHeader("grpc-accept-encoding", "deflate, gzip")))
+      Codecs.negotiate(request) should be(Gzip)
+    }
+
   }
 
   "Detecting message encoding from remote" should {


### PR DESCRIPTION
cherry pick 24c42730804b190b0c2f78aad0ac448abc0024e #850 and 10ff8fcf4ad54791df5d97650a3d80a41bdacaa4 #851
