### PR TITLE
CI jobs for 1.3.x

### DIFF
--- a/.github/workflows/nightly-snapshot-dependency-test.yml
+++ b/.github/workflows/nightly-snapshot-dependency-test.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           # we don't know what commit the last tag was it's safer to get entire repo so previousStableVersion resolves
           fetch-depth: 0
-          ref: 1.2.x
+          ref: 1.3.x
           
       - name: Setup Java 8
         uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0

--- a/.github/workflows/publish-1.3-snapshots.yml
+++ b/.github/workflows/publish-1.3-snapshots.yml
@@ -6,9 +6,11 @@
 # This file is part of the Apache Pekko project, which was derived from Akka.
 #
 
-name: Publish 1.2 Snapshots
+name: Publish 1.3 Snapshots
 
 on:
+  schedule:
+    - cron: "0 4 * * *"
   workflow_dispatch:
 
 jobs:
@@ -22,7 +24,7 @@ jobs:
         with:
           # we don't know what commit the last tag was it's safer to get entire repo so previousStableVersion resolves
           fetch-depth: 0
-          ref: 1.2.x
+          ref: 1.3.x
           
       - name: Setup Java 8
         uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0


### PR DESCRIPTION
Focus on 1.3.x testing and reduce importance of 1.2.x testing.
Bring Scala versions used in CI jobs up to date with what is used in Dependencies.scala for the the given branches.