### PR TITLE
Use FastFuture for already completed marshalling futures

### DIFF
--- a/benchmarks/src/main/scala/org/apache/pekko/grpc/GrpcMarshallingBenchmark.scala
+++ b/benchmarks/src/main/scala/org/apache/pekko/grpc/GrpcMarshallingBenchmark.scala
@@ -14,6 +14,8 @@
 package org.apache.pekko.grpc
 
 import scala.concurrent.Await
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
 import scala.concurrent.duration.Duration
 
 import com.google.protobuf.{ Any => JavaAny, ByteString => JavaByteString }
@@ -52,6 +54,7 @@ class GrpcMarshallingBenchmark extends CommonBenchmark {
         isTrailer = false))
 
   val mat = SystemMaterializer(system).materializer
+  implicit val ec: ExecutionContext = mat.executionContext
 
   @Benchmark
   def marshall(): HttpResponse = {
@@ -66,6 +69,17 @@ class GrpcMarshallingBenchmark extends CommonBenchmark {
   @Benchmark
   def unmarshallStrict(): ServerReflectionRequest = {
     Await.result(GrpcMarshalling.unmarshal(entity), Duration.Inf)
+  }
+
+  // Unmarshalling a strict entity and then chaining the transforms a generated handler applies to it.
+  // This is the shape of the call chain in generated (and hand written) unary handlers.
+  @Benchmark
+  def unmarshallStrictChained(): ServerReflectionRequest = {
+    val result = GrpcMarshalling
+      .unmarshal(entity)
+      .flatMap(req => Future.successful(req))
+      .map(identity)
+    Await.result(result, Duration.Inf)
   }
 
   @Benchmark

--- a/benchmarks/src/main/scala/org/apache/pekko/grpc/ScalaUnaryHandlerBenchmark.scala
+++ b/benchmarks/src/main/scala/org/apache/pekko/grpc/ScalaUnaryHandlerBenchmark.scala
@@ -48,6 +48,7 @@ import pekko.http.scaladsl.model.HttpResponse
 import pekko.http.scaladsl.model.StatusCodes
 import pekko.http.scaladsl.model.TransferEncodings
 import pekko.http.scaladsl.model.Uri
+import pekko.http.scaladsl.util.FastFuture
 import pekko.stream.Materializer
 import pekko.stream.SystemMaterializer
 import pekko.stream.scaladsl.Sink
@@ -66,7 +67,11 @@ class ScalaUnaryHandlerBenchmark extends CommonBenchmark {
   private val writer = GrpcProtocolNative.newWriter(Identity)
   private val requestMessage = HelloRequest("Alice")
   private val responseMessage = HelloReply("Hello, Alice")
-  private val implementation = new BenchmarkGreeterService(responseMessage)
+  // A typical service implementation, returning an ordinary completed Future.
+  private val implementation = new BenchmarkGreeterService(Future.successful(responseMessage))
+  // A service implementation that returns an already completed FastFuture, so that every transform
+  // the handler chains onto it can also run directly instead of being scheduled.
+  private val fastImplementation = new BenchmarkGreeterService(FastFuture.successful(responseMessage))
 
   private val request: HttpRequest = {
     val data =
@@ -88,7 +93,7 @@ class ScalaUnaryHandlerBenchmark extends CommonBenchmark {
   private val generatedHandler: HttpRequest => Future[HttpResponse] =
     GreeterServiceHandler(implementation)
 
-  private val oldStyleHandler: HttpRequest => Future[HttpResponse] = {
+  private def oldStyleHandlerFor(implementation: GreeterService): HttpRequest => Future[HttpResponse] = {
     val notFound = Future.successful(HttpResponse(StatusCodes.NotFound))
     val unsupportedMediaType = Future.successful(HttpResponse(StatusCodes.UnsupportedMediaType))
     val spi = TelemetryExtension(system).spi
@@ -117,6 +122,9 @@ class ScalaUnaryHandlerBenchmark extends CommonBenchmark {
       }
   }
 
+  private val oldStyleHandler: HttpRequest => Future[HttpResponse] = oldStyleHandlerFor(implementation)
+  private val fastOldStyleHandler: HttpRequest => Future[HttpResponse] = oldStyleHandlerFor(fastImplementation)
+
   @Benchmark
   def generatedUnaryStrictRequestProcessing(blackhole: Blackhole): Unit =
     consumeResponse(Await.result(generatedHandler(request), Duration.Inf), blackhole)
@@ -124,6 +132,10 @@ class ScalaUnaryHandlerBenchmark extends CommonBenchmark {
   @Benchmark
   def oldStyleUnaryStrictRequestProcessing(blackhole: Blackhole): Unit =
     consumeResponse(Await.result(oldStyleHandler(request), Duration.Inf), blackhole)
+
+  @Benchmark
+  def oldStyleUnaryStrictRequestProcessingFastImplementation(blackhole: Blackhole): Unit =
+    consumeResponse(Await.result(fastOldStyleHandler(request), Duration.Inf), blackhole)
 
   private def consumeResponse(response: HttpResponse, blackhole: Blackhole): Unit = {
     blackhole.consume(response.status)
@@ -139,9 +151,9 @@ class ScalaUnaryHandlerBenchmark extends CommonBenchmark {
   def tearDown(): Unit =
     system.terminate()
 
-  private final class BenchmarkGreeterService(response: HelloReply) extends GreeterService {
+  private final class BenchmarkGreeterService(response: Future[HelloReply]) extends GreeterService {
     override def sayHello(in: HelloRequest): Future[HelloReply] =
-      Future.successful(response)
+      response
 
     override def itKeepsTalking(in: Source[HelloRequest, NotUsed]): Future[HelloReply] =
       throw new UnsupportedOperationException("itKeepsTalking")

--- a/runtime/src/main/scala/org/apache/pekko/grpc/internal/HardcodedServiceDiscovery.scala
+++ b/runtime/src/main/scala/org/apache/pekko/grpc/internal/HardcodedServiceDiscovery.scala
@@ -16,11 +16,12 @@ package org.apache.pekko.grpc.internal
 import org.apache.pekko
 import pekko.discovery.{ Lookup, ServiceDiscovery }
 import pekko.discovery.ServiceDiscovery.Resolved
+import pekko.http.scaladsl.util.FastFuture
 
 import scala.concurrent.Future
 import scala.concurrent.duration.FiniteDuration
 
 class HardcodedServiceDiscovery(resolved: Resolved) extends ServiceDiscovery {
   override def lookup(lookup: Lookup, resolveTimeout: FiniteDuration): Future[Resolved] =
-    Future.successful(resolved)
+    FastFuture.successful(resolved)
 }

--- a/runtime/src/main/scala/org/apache/pekko/grpc/internal/PekkoHttpClientUtils.scala
+++ b/runtime/src/main/scala/org/apache/pekko/grpc/internal/PekkoHttpClientUtils.scala
@@ -29,6 +29,7 @@ import pekko.http.scaladsl.{ ClientTransport, ConnectionContext, Http, HttpsConn
 import pekko.http.scaladsl.model._
 import pekko.http.scaladsl.model.headers.RawHeader
 import pekko.http.scaladsl.settings.ClientConnectionSettings
+import pekko.http.scaladsl.util.FastFuture
 import pekko.stream.{ Materializer, QueueOfferResult }
 import pekko.stream.scaladsl.{ Keep, Sink, Source }
 import pekko.util.ByteString
@@ -294,7 +295,7 @@ object PekkoHttpClientUtils {
           if (response.status != StatusCodes.OK) {
             response.entity.discardBytes()
             val failure = mapToStatusException(response, immutable.Seq.empty)
-            Source.failed(failure).mapMaterializedValue(_ => Future.failed(failure))
+            Source.failed(failure).mapMaterializedValue(_ => FastFuture.failed(failure))
           } else {
             Codecs.detect(response) match {
               case Success(codec) =>
@@ -338,7 +339,7 @@ object PekkoHttpClientUtils {
                   .via(reader.dataFrameDecoder)
                   .map(deserializer.deserialize)
                   .mapMaterializedValue(_ =>
-                    Future.successful(new GrpcResponseMetadata() {
+                    FastFuture.successful(new GrpcResponseMetadata() {
                       override def headers: pekko.grpc.scaladsl.Metadata =
                         new HeaderMetadataImpl(response.headers)
 
@@ -355,7 +356,7 @@ object PekkoHttpClientUtils {
                           .asJava
                     }))
               case Failure(e) =>
-                Source.failed[O](e).mapMaterializedValue(_ => Future.failed(e))
+                Source.failed[O](e).mapMaterializedValue(_ => FastFuture.failed(e))
             }
           }
         }
@@ -367,9 +368,9 @@ object PekkoHttpClientUtils {
     val allHeaders = response.headers ++ trailers
     allHeaders.find(_.name == "grpc-status").map(_.value) match {
       case Some("0") =>
-        Future.successful(())
+        FastFuture.successful(())
       case _ =>
-        Future.failed(mapToStatusException(response, trailers))
+        FastFuture.failed(mapToStatusException(response, trailers))
     }
   }
 

--- a/runtime/src/main/scala/org/apache/pekko/grpc/internal/RequestBuilderImpl.scala
+++ b/runtime/src/main/scala/org/apache/pekko/grpc/internal/RequestBuilderImpl.scala
@@ -19,6 +19,7 @@ import org.apache.pekko
 import pekko.NotUsed
 import pekko.annotation.{ InternalApi, InternalStableApi }
 import pekko.grpc.{ GrpcClientSettings, GrpcResponseMetadata, GrpcServiceException, GrpcSingleResponse }
+import pekko.http.scaladsl.util.FastFuture
 import pekko.stream.{ Graph, Materializer, SourceShape }
 import pekko.stream.javadsl.{ Source => JavaSource }
 import pekko.stream.scaladsl.{ Keep, Sink, Source }
@@ -349,7 +350,7 @@ object RequestBuilderImpl {
   }
 
   def richError[U]: PartialFunction[Throwable, Future[U]] = {
-    case item => Future.failed(RequestBuilderImpl.lift(item))
+    case item => FastFuture.failed(RequestBuilderImpl.lift(item))
   }
 
   def lift(item: Throwable): scala.Throwable = item match {

--- a/runtime/src/main/scala/org/apache/pekko/grpc/scaladsl/GrpcExceptionHandler.scala
+++ b/runtime/src/main/scala/org/apache/pekko/grpc/scaladsl/GrpcExceptionHandler.scala
@@ -21,6 +21,7 @@ import pekko.grpc.{ GrpcServiceException, Trailers }
 import pekko.grpc.GrpcProtocol.GrpcProtocolWriter
 import pekko.grpc.internal.{ GrpcMetadataImpl, GrpcResponseHelpers, MissingParameterException }
 import pekko.http.scaladsl.model.HttpResponse
+import pekko.http.scaladsl.util.FastFuture
 import io.grpc.{ Status, StatusRuntimeException }
 import org.apache.pekko.http.scaladsl.model.http2.PeerClosedStreamException
 
@@ -63,6 +64,7 @@ object GrpcExceptionHandler {
   def from(mapper: PartialFunction[Throwable, Trailers])(
       implicit system: ClassicActorSystemProvider,
       writer: GrpcProtocolWriter): PartialFunction[Throwable, Future[HttpResponse]] =
-    mapper.orElse(defaultMapper(system.classicSystem)).andThen(s => Future.successful(GrpcResponseHelpers.status(s)))
+    mapper.orElse(defaultMapper(system.classicSystem)).andThen(s =>
+      FastFuture.successful(GrpcResponseHelpers.status(s)))
 
 }

--- a/runtime/src/main/scala/org/apache/pekko/grpc/scaladsl/GrpcMarshalling.scala
+++ b/runtime/src/main/scala/org/apache/pekko/grpc/scaladsl/GrpcMarshalling.scala
@@ -57,7 +57,7 @@ object GrpcMarshalling {
   def negotiated[T](req: HttpRequest, f: (GrpcProtocolReader, GrpcProtocolWriter) => Future[T]): Option[Future[T]] =
     GrpcProtocol.negotiate(req).map {
       case (Success(reader), writer) => f(reader, writer)
-      case (Failure(ex), _)          => Future.failed(ex)
+      case (Failure(ex), _)          => FastFuture.failed(ex)
     }
 
   def unmarshal[T](data: Source[ByteString, Any])(
@@ -69,7 +69,7 @@ object GrpcMarshalling {
   def unmarshal[T](
       entity: HttpEntity)(implicit u: ProtobufSerializer[T], mat: Materializer, reader: GrpcProtocolReader): Future[T] =
     entity match {
-      case HttpEntity.Strict(_, data) => Future.fromTry(Try(u.deserialize(reader.decodeSingleFrame(data))))
+      case HttpEntity.Strict(_, data) => FastFuture(Try(u.deserialize(reader.decodeSingleFrame(data))))
       case _                          => unmarshal(entity.dataBytes)
     }
 
@@ -77,7 +77,7 @@ object GrpcMarshalling {
       implicit u: ProtobufSerializer[T],
       @nowarn("msg=is never used") mat: Materializer,
       reader: GrpcProtocolReader): Future[Source[T, NotUsed]] = {
-    Future.successful(
+    FastFuture.successful(
       data
         .mapMaterializedValue(_ => NotUsed)
         .via(reader.dataFrameDecoder)

--- a/runtime/src/main/scala/org/apache/pekko/grpc/scaladsl/ServiceHandler.scala
+++ b/runtime/src/main/scala/org/apache/pekko/grpc/scaladsl/ServiceHandler.scala
@@ -19,16 +19,17 @@ import pekko.grpc.GrpcProtocol
 import pekko.grpc.internal.{ GrpcProtocolWeb, GrpcProtocolWebText }
 import pekko.http.javadsl.{ model => jmodel }
 import pekko.http.scaladsl.model.{ HttpRequest, HttpResponse, StatusCodes }
+import pekko.http.scaladsl.util.FastFuture
 
 import scala.concurrent.Future
 
 @ApiMayChange
 object ServiceHandler {
 
-  private[scaladsl] val notFound: Future[HttpResponse] = Future.successful(HttpResponse(StatusCodes.NotFound))
+  private[scaladsl] val notFound: Future[HttpResponse] = FastFuture.successful(HttpResponse(StatusCodes.NotFound))
 
   private[scaladsl] val unsupportedMediaType: Future[HttpResponse] =
-    Future.successful(HttpResponse(StatusCodes.UnsupportedMediaType))
+    FastFuture.successful(HttpResponse(StatusCodes.UnsupportedMediaType))
 
   private def matchesVariant(variants: Set[GrpcProtocol])(request: jmodel.HttpRequest) =
     variants.exists(_.mediaTypes.contains(request.entity.getContentType.mediaType))

--- a/runtime/src/test/scala/org/apache/pekko/grpc/scaladsl/GrpcMarshallingSpec.scala
+++ b/runtime/src/test/scala/org/apache/pekko/grpc/scaladsl/GrpcMarshallingSpec.scala
@@ -1,0 +1,113 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.pekko.grpc.scaladsl
+
+import scala.concurrent.{ Await, ExecutionContext }
+import scala.concurrent.duration._
+import scala.util.Success
+
+import com.google.protobuf.ByteString
+import com.google.protobuf.any.{ Any => ScalapbAny }
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+import org.apache.pekko
+import pekko.actor.ActorSystem
+import pekko.grpc.GrpcProtocol.{ GrpcProtocolReader, GrpcProtocolWriter }
+import pekko.grpc.internal.{ AbstractGrpcProtocol, GrpcProtocolNative, Identity }
+import pekko.http.scaladsl.model.HttpEntity
+import pekko.stream.{ Materializer, SystemMaterializer }
+import pekko.util.{ ByteString => PekkoByteString }
+
+class GrpcMarshallingSpec extends AnyWordSpec with Matchers with BeforeAndAfterAll {
+
+  private implicit val system: ActorSystem = ActorSystem("GrpcMarshallingSpec")
+  private implicit val mat: Materializer = SystemMaterializer(system).materializer
+  private implicit val serializer: ScalapbProtobufSerializer[ScalapbAny] =
+    new ScalapbProtobufSerializer(ScalapbAny)
+  private implicit val reader: GrpcProtocolReader = GrpcProtocolNative.newReader(Identity)
+  private implicit val writer: GrpcProtocolWriter = GrpcProtocolNative.newWriter(Identity)
+
+  /**
+   * An ExecutionContext that refuses to run anything, so that a transform which needs to be
+   * scheduled fails loudly instead of silently completing on another thread.
+   */
+  private object NoDispatch extends ExecutionContext {
+    override def execute(runnable: Runnable): Unit =
+      throw new AssertionError("transform was scheduled on an ExecutionContext instead of completing directly")
+    override def reportFailure(cause: Throwable): Unit = throw cause
+  }
+
+  private val message = ScalapbAny("type.googleapis.com/test", ByteString.copyFromUtf8("payload"))
+
+  private def strictEntity(data: PekkoByteString): HttpEntity.Strict =
+    HttpEntity.Strict(GrpcProtocolNative.contentType, data)
+
+  private val validEntity =
+    strictEntity(AbstractGrpcProtocol.encodeFrameData(serializer.serialize(message), isCompressed = false,
+      isTrailer = false))
+
+  // A single zero byte is an invalid protobuf tag, so deserialization of this frame fails.
+  private val corruptEntity =
+    strictEntity(
+      AbstractGrpcProtocol.encodeFrameData(PekkoByteString(0), isCompressed = false, isTrailer = false))
+
+  override protected def afterAll(): Unit = Await.result(system.terminate(), 10.seconds)
+
+  "The scaladsl GrpcMarshalling" should {
+
+    "complete unmarshal of a strict entity directly, without scheduling" in {
+      val unmarshalled = GrpcMarshalling.unmarshal[ScalapbAny](validEntity)
+
+      unmarshalled.value should be(Some(Success(message)))
+      // A generated handler chains further transforms onto this future; they must not need a dispatch either.
+      unmarshalled.flatMap(a => GrpcMarshalling.unmarshal[ScalapbAny](validEntity).map(_ => a)(NoDispatch))(
+        NoDispatch).value should be(Some(Success(message)))
+    }
+
+    "complete a failed unmarshal of a strict entity directly, without scheduling" in {
+      val unmarshalled = GrpcMarshalling.unmarshal[ScalapbAny](corruptEntity)
+
+      unmarshalled.value.map(_.isFailure) should be(Some(true))
+      unmarshalled.recover { case _ => message }(NoDispatch).value should be(Some(Success(message)))
+    }
+
+    "complete unmarshalStream directly, without scheduling" in {
+      val unmarshalled = GrpcMarshalling.unmarshalStream[ScalapbAny](validEntity)
+
+      unmarshalled.value.map(_.isSuccess) should be(Some(true))
+      unmarshalled.map(_ => message)(NoDispatch).value should be(Some(Success(message)))
+    }
+
+    "complete the exception handler response directly, without scheduling" in {
+      val handled =
+        GrpcExceptionHandler.from(GrpcExceptionHandler.defaultMapper(system))(system, writer)(
+          new RuntimeException("boom"))
+
+      handled.value.map(_.isSuccess) should be(Some(true))
+      handled.map(_.status.intValue)(NoDispatch).value should be(Some(Success(200)))
+      handled.value.get.get.getHeader("grpc-status").get.value should be("13")
+    }
+
+    "complete the not-found and unsupported-media-type responses directly, without scheduling" in {
+      ServiceHandler.notFound.map(_.status.intValue)(NoDispatch).value should be(Some(Success(404)))
+      ServiceHandler.unsupportedMediaType.map(_.status.intValue)(NoDispatch).value should be(Some(Success(415)))
+    }
+  }
+}


### PR DESCRIPTION
### Motivation

`GrpcMarshalling.unmarshal` on a strict entity, `unmarshalStream`, the negotiation failure path, `GrpcExceptionHandler.from` and the `ServiceHandler` `notFound` / `unsupportedMediaType` responses all produce futures that are already completed by the time they are returned, but they were built with `Future.successful` / `Future.failed` / `Future.fromTry`. Every transform a handler chains onto one of those is then scheduled on an `ExecutionContext`, even though the value is already available.

Pekko HTTP's `FastFuture` exists for exactly this: `FulfilledFuture` / `ErrorFuture` override `transform` and `transformWith`, so plain `.map` / `.flatMap` / `.recoverWith` on them run directly on the calling thread and return another already-completed future, rather than going through the dispatcher.

This is the `FastFuture` part of #862, split out on its own so it can be reviewed and merged independently of the larger unary handler rework in that PR.

### Modification

Cherry-picked `Use FastFuture for completed futures.` from #862 (authored by @timw) unchanged — `FastFuture.apply` / `successful` / `failed` in place of the `Future` equivalents in `GrpcMarshalling`, `GrpcExceptionHandler`, `ServiceHandler`, `PekkoHttpClientUtils`, `RequestBuilderImpl` and `HardcodedServiceDiscovery`.

On top of that:

- New `runtime/src/test/scala/org/apache/pekko/grpc/scaladsl/GrpcMarshallingSpec.scala`. Each test asserts both that the future is already completed (`.value` is defined) and that a transform chained onto it still completes when given an `ExecutionContext` that throws if anything is scheduled on it. Covers `unmarshal` of a strict entity (success and parse failure), `unmarshalStream`, `GrpcExceptionHandler.from`, and `ServiceHandler.notFound` / `unsupportedMediaType`.
- New `GrpcMarshallingBenchmark.unmarshallStrictChained`, which measures `unmarshal(strict).flatMap(...).map(...)` — the chain shape a generated unary handler builds — rather than `unmarshal` alone.
- New `ScalaUnaryHandlerBenchmark.oldStyleUnaryStrictRequestProcessingFastImplementation`. `BenchmarkGreeterService` now takes the response `Future`, so the same handler can be benchmarked against a service returning an ordinary `Future.successful` (what user code normally does) and one returning `FastFuture.successful`.

No public API, binary shape or wire format changes; `mimaReportBinaryIssues` is clean.

### Result

The measurable effect depends on what the service implementation returns, and the two benchmark variants are there to make that explicit rather than report one flattering number.

A chain stays direct only while every step returns an already-completed fast future. `unmarshal(...).flatMap(impl)` now runs `impl` inline, but if `impl` hands back a plain `Future.successful` — a `KeptPromise` — the following `.map(marshal)` and `.recoverWith(...)` are scheduled as before. So a typical service saves one dispatch out of three; a service that returns `FastFuture.successful` keeps the whole chain inline.

Intel Core i7-4770HQ, macOS 12.7.6, Temurin 17.0.19, `-f 2 -wi 5 -i 5`. Both columns run with the benchmark sources from this PR, differing only in the runtime sources.

| Benchmark | before (ops/s) | after (ops/s) |
| --- | --- | --- |
| `GrpcMarshallingBenchmark.unmarshallStrict` | 13,765,653 ± 2,221,933 | 16,054,190 ± 944,574 |
| `GrpcMarshallingBenchmark.unmarshallStrictChained` | 91,705 ± 17,593 | 97,672 ± 4,849 |
| `ScalaUnaryHandlerBenchmark.generatedUnaryStrictRequestProcessing` | 109,880 ± 28,583 | 112,235 ± 7,581 |
| `ScalaUnaryHandlerBenchmark.oldStyleUnaryStrictRequestProcessing` | 47,765 ± 11,038 | 48,860 ± 12,315 |
| `ScalaUnaryHandlerBenchmark.oldStyleUnaryStrictRequestProcessingFastImplementation` | 51,448 ± 4,540 | 103,650 ± 24,119 |

Reading that honestly:

- With a service returning `FastFuture.successful`, the old-style unary handler roughly doubles (51k -> 104k ops/s). That is the real win, and it applies to existing generated code without regeneration.
- With a service returning a plain `Future.successful`, the improvement is inside the noise on this hardware. One saved dispatch is small next to the `Await` park in the benchmark harness.
- Nothing regresses. `unmarshallStrict` and `unmarshallStrictChained` also become noticeably more stable run to run (the error bars shrink), which is consistent with dispatches being removed.

Worth noting for anyone comparing against the numbers in #862: the `ScalaHandlerBenchmark` there changes `BenchmarkGreeterService.sayHello` to return `FastFuture.successful(response)`, so its old-style handler figures are measuring the second row of that list, not the first.

### Tests

- `sbt runtime/test` - 139 succeeded, 0 failed
- New `scaladsl/GrpcMarshallingSpec` is directional: 5/5 tests fail against `main`'s runtime sources, 5/5 pass with this change
- `sbt checkCodeStyle` - success
- `sbt +headerCheckAll` - success (via `headerCreateAll`, no changes)
- `sbt grpcVersionSyncCheck googleProtobufVersionSyncCheck mimaReportBinaryIssues` - success, no binary compatibility problems
- `sbt "benchmarks/Jmh/run -f 2 -wi 5 -i 5 org.apache.pekko.grpc.ScalaUnaryHandlerBenchmark org.apache.pekko.grpc.GrpcMarshallingBenchmark.unmarshallStrict"` - results above
- Not run: Gradle, Maven and sbt scripted suites - no plugin or codegen changes

### References

Refs #862
