### PR TITLE
Ship a complete LICENSE and NOTICE in the assembly jars

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -52,6 +52,11 @@ jobs:
           cp .jvmopts-ci .jvmopts
           sbt grpcVersionSyncCheck googleProtobufVersionSyncCheck mimaReportBinaryIssues
 
+      - name: Assembly license check
+        run: |-
+          cp .jvmopts-ci .jvmopts
+          sbt checkAssemblyLicenses
+
   compile-benchmarks:
     name: Compile Benchmarks
     runs-on: ubuntu-latest

--- a/build.sbt
+++ b/build.sbt
@@ -49,6 +49,10 @@ ThisBuild / javafmtFormatterCompatibleJavaVersion := 17
 
 addCommandAlias("checkCodeStyle", "scalafmtCheckAll; scalafmtSbtCheck; javafmtCheckAll; +headerCheckAll")
 addCommandAlias("applyCodeStyle", "+headerCreateAll; scalafmtAll; scalafmtSbt; javafmtAll")
+addCommandAlias(
+  "checkAssemblyLicenses",
+  "codegen/assemblyLicenseCheck; codegen/assemblyMetaInfCheck; " +
+  "scalapb-protoc-plugin/assemblyLicenseCheck; scalapb-protoc-plugin/assemblyMetaInfCheck")
 
 val pekkoGrpcCodegenId = s"$pekkoPrefix-codegen"
 lazy val codegen = Project(id = "codegen", base = file("codegen"))
@@ -58,12 +62,14 @@ lazy val codegen = Project(id = "codegen", base = file("codegen"))
   .settings(Dependencies.codegen)
   .settings(resolvers += Resolver.sbtPluginRepo("releases"))
   .settings(MetaInfLicenseNoticeCopy.assemblySettings)
+  .settings(AssemblyLicenseCheck.settings)
   .settings(
     name := s"$pekkoPrefix-codegen",
     mkBatAssemblyTask := {
       val file = assembly.value
       Assemblies.mkBatAssembly(file)
     },
+    AssemblyLicenseCheck.assemblyMetaInfArchives += mkBatAssemblyTask.value,
     buildInfoKeys ++= Seq[BuildInfoKey](organization, name, version, scalaVersion, sbtVersion),
     buildInfoKeys += "runtimeArtifactName" -> pekkoGrpcRuntimeName,
     buildInfoKeys += "pekkoVersion" -> Dependencies.Versions.pekko,
@@ -80,7 +86,9 @@ lazy val codegen = Project(id = "codegen", base = file("codegen"))
     (assembly / assemblyOption) := (assembly / assemblyOption).value.withPrependShellScript(
       Some(sbtassembly.AssemblyPlugin.defaultUniversalScript(shebang = true))),
     (assembly / assemblyMergeStrategy) := {
-      case PathList("META-INF", "LICENSE")                          => MergeStrategy.discard
+      // our own META-INF/LICENSE and META-INF/NOTICE cover the bundled 3rd party classes,
+      // so they win over the ones the dependencies bring in
+      case PathList("META-INF", "LICENSE" | "NOTICE")               => MergeStrategy.preferProject
       case PathList("META-INF", "MANIFEST.MF")                      => MergeStrategy.discard
       case PathList("META-INF", "versions", _, "module-info.class") => MergeStrategy.discard
       case "LICENSE" | "LICENSE.txt" | "NOTICE"                     => MergeStrategy.discard
@@ -130,15 +138,15 @@ val pekkoGrpcProtocPluginId = s"$pekkoPrefix-scalapb-protoc-plugin"
 lazy val scalapbProtocPlugin = Project(id = "scalapb-protoc-plugin", base = file("scalapb-protoc-plugin"))
   .disablePlugins(MimaPlugin)
   .settings(MetaInfLicenseNoticeCopy.assemblySettings)
+  .settings(AssemblyLicenseCheck.settings)
+  .settings(Dependencies.scalapbProtocPlugin)
   .settings(
     name := s"$pekkoPrefix-scalapb-protoc-plugin",
-    libraryDependencies += {
-      Dependencies.Compile.scalapbCompilerPlugin
-    },
     mkBatAssemblyTask := {
       val file = assembly.value
       Assemblies.mkBatAssembly(file)
     },
+    AssemblyLicenseCheck.assemblyMetaInfArchives += mkBatAssemblyTask.value,
     (Compile / assembly / artifact) := {
       val art = (Compile / assembly / artifact).value
       art.withClassifier(Some("assembly"))
@@ -147,6 +155,9 @@ lazy val scalapbProtocPlugin = Project(id = "scalapb-protoc-plugin", base = file
     (assembly / assemblyOption) := (assembly / assemblyOption).value.withPrependShellScript(
       Some(sbtassembly.AssemblyPlugin.defaultUniversalScript(shebang = true))),
     (assembly / assemblyMergeStrategy) := {
+      // our own META-INF/LICENSE and META-INF/NOTICE cover the bundled 3rd party classes,
+      // so they win over the ones the dependencies bring in
+      case PathList("META-INF", "LICENSE" | "NOTICE")               => MergeStrategy.preferProject
       case PathList("META-INF", "MANIFEST.MF")                      => MergeStrategy.discard
       case PathList("META-INF", "versions", _, "module-info.class") => MergeStrategy.discard
       case "LICENSE" | "LICENSE.txt" | "NOTICE"                     => MergeStrategy.discard

--- a/legal/AssemblyLicense.txt
+++ b/legal/AssemblyLicense.txt
@@ -220,37 +220,12 @@ com.google.j2objc:j2objc-annotations
 io.grpc:grpc-api
 io.grpc:grpc-protobuf
 io.grpc:grpc-protobuf-lite
-org.checkerframework:checker-qual
+org.jspecify:jspecify
 org.playframework.twirl:twirl-api
 org.scala-lang:scala-library
 org.scala-lang:scala3-library
 org.scala-lang.modules:scala-collection-compat
 org.scala-lang.modules:scala-xml
-
-----
-
-Checker Framework qualifiers
-Copyright 2004-present by the Checker Framework developers
-
-MIT License:
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
 
 ----
 

--- a/project/AssemblyLicenseCheck.scala
+++ b/project/AssemblyLicenseCheck.scala
@@ -1,0 +1,116 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import java.util.zip.ZipFile
+
+import sbt._
+import sbt.Keys._
+import sbtassembly.AssemblyKeys._
+import org.mdedetrich.apache.sonatype.ApacheSonatypePlugin.autoImport.{
+  apacheSonatypeLicenseFile,
+  apacheSonatypeNoticeFile
+}
+
+/**
+ * Guards the LICENSE and NOTICE files that ship in the assembly jars.
+ *
+ * The assembly jars bundle classes from 3rd party projects, so their `META-INF/LICENSE` and
+ * `META-INF/NOTICE` have to account for those projects. Those files are curated by hand in
+ * `legal/`, because most of the bundled jars carry no NOTICE of their own and the text has to be
+ * taken from the upstream projects. These tasks stop the curated files from drifting away from
+ * what the jars actually bundle.
+ */
+object AssemblyLicenseCheck {
+
+  val assemblyBundledModules =
+    taskKey[Seq[String]]("The `organization:name` ids of the 3rd party modules bundled into the assembly jar")
+  val assemblyLicenseCheck =
+    taskKey[Unit]("Check that every module bundled into the assembly jar is named in the assembly LICENSE file")
+  val assemblyMetaInfArchives =
+    taskKey[Seq[File]]("The published archives that should carry the assembly LICENSE and NOTICE files")
+  val assemblyMetaInfCheck =
+    taskKey[Unit]("Check that the published archives ship the assembly LICENSE and NOTICE files in META-INF")
+
+  /** A module id as listed in the assembly LICENSE file: `organization:name`, optionally `:version`. */
+  private val ModuleId = """^([a-zA-Z0-9][\w.\-]*):([a-zA-Z0-9][\w.\-]*)(?::.*)?$""".r
+
+  lazy val settings: Seq[Setting[_]] = Seq(
+    assemblyBundledModules := {
+      val suffix = "_" + CrossVersion.binaryScalaVersion(scalaVersion.value)
+      val modules = (assembly / fullClasspath).value.flatMap(_.get(moduleID.key))
+      modules
+        .filterNot(_.organization == "org.apache.pekko") // our own modules, covered by the ASF header
+        .map { module =>
+          val name = if (module.name.endsWith(suffix)) module.name.dropRight(suffix.length) else module.name
+          s"${module.organization}:$name"
+        }
+        .distinct
+        .sorted
+    },
+    assemblyLicenseCheck := {
+      val log = streams.value.log
+      val licenseFile = apacheSonatypeLicenseFile.value
+      val listed = IO.readLines(licenseFile).map(_.trim).collect { case ModuleId(org, module) => s"$org:$module" }.toSet
+      val bundled = assemblyBundledModules.value
+
+      val extra = (listed -- bundled).toSeq.sorted
+      if (extra.nonEmpty)
+        // the assembly jars are cross built, so a module can be listed for a Scala version other than this one
+        log.warn(
+          s"${licenseFile.getName} lists modules that ${name.value} does not bundle for Scala ${scalaVersion.value}, " +
+          s"check whether they are still needed: ${extra.mkString(", ")}")
+
+      val missing = bundled.filterNot(listed)
+      if (missing.nonEmpty)
+        sys.error(
+          s"${name.value} bundles modules that ${licenseFile.getName} does not account for: ${missing.mkString(", ")}")
+
+      log.info(s"${licenseFile.getName} accounts for all ${bundled.size} modules bundled by ${name.value}")
+    },
+    assemblyMetaInfArchives := Seq(assembly.value),
+    assemblyMetaInfCheck := {
+      val log = streams.value.log
+      val expected =
+        Seq("META-INF/LICENSE" -> apacheSonatypeLicenseFile.value, "META-INF/NOTICE" -> apacheSonatypeNoticeFile.value)
+
+      assemblyMetaInfArchives.value.foreach { archive =>
+        val zip = new ZipFile(archive)
+        val problems =
+          try expected.flatMap { case (path, file) =>
+              Option(zip.getEntry(path)) match {
+                case None =>
+                  Some(s"$path is missing, expected a copy of $file")
+                case Some(entry) =>
+                  val actual = {
+                    val in = zip.getInputStream(entry)
+                    try in.readAllBytes()
+                    finally in.close()
+                  }
+                  if (actual.sameElements(IO.readBytes(file))) None
+                  else Some(s"$path does not match $file")
+              }
+            }
+          finally zip.close()
+
+        if (problems.nonEmpty)
+          sys.error(s"${archive.getName} has license problems: ${problems.mkString("; ")}")
+
+        log.info(s"${archive.getName} ships ${expected.map(_._1).mkString(" and ")}")
+      }
+    })
+
+}

--- a/project/AssemblyLicenseCheck.scala
+++ b/project/AssemblyLicenseCheck.scala
@@ -15,9 +15,10 @@
  * limitations under the License.
  */
 
-import java.util.zip.ZipFile
+import java.io.IOException
 
 import sbt._
+import sbt.io.Using
 import sbt.Keys._
 import sbtassembly.AssemblyKeys._
 import org.mdedetrich.apache.sonatype.ApacheSonatypePlugin.autoImport.{
@@ -88,23 +89,23 @@ object AssemblyLicenseCheck {
         Seq("META-INF/LICENSE" -> apacheSonatypeLicenseFile.value, "META-INF/NOTICE" -> apacheSonatypeNoticeFile.value)
 
       assemblyMetaInfArchives.value.foreach { archive =>
-        val zip = new ZipFile(archive)
         val problems =
-          try expected.flatMap { case (path, file) =>
-              Option(zip.getEntry(path)) match {
-                case None =>
-                  Some(s"$path is missing, expected a copy of $file")
-                case Some(entry) =>
-                  val actual = {
-                    val in = zip.getInputStream(entry)
-                    try in.readAllBytes()
-                    finally in.close()
-                  }
-                  if (actual.sameElements(IO.readBytes(file))) None
-                  else Some(s"$path does not match $file")
+          try Using.zipFile(archive) { zip =>
+              expected.flatMap { case (path, file) =>
+                Option(zip.getEntry(path)) match {
+                  case None =>
+                    Some(s"$path is missing, expected a copy of $file")
+                  case Some(entry) =>
+                    val actual = Using.zipEntry(zip)(entry)(_.readAllBytes())
+                    if (actual.sameElements(IO.readBytes(file))) None
+                    else Some(s"$path does not match $file")
+                }
               }
             }
-          finally zip.close()
+          catch {
+            // the archive name is not part of the messages the zip classes throw
+            case e: IOException => sys.error(s"${archive.getName} could not be read as a zip archive: $e")
+          }
 
         if (problems.nonEmpty)
           sys.error(s"${archive.getName} has license problems: ${problems.mkString("; ")}")

--- a/project/AssemblyLicenseCheck.scala
+++ b/project/AssemblyLicenseCheck.scala
@@ -16,6 +16,7 @@
  */
 
 import java.io.IOException
+import java.nio.charset.StandardCharsets
 
 import sbt._
 import sbt.io.Using
@@ -45,6 +46,25 @@ object AssemblyLicenseCheck {
     taskKey[Seq[File]]("The published archives that should carry the assembly LICENSE and NOTICE files")
   val assemblyMetaInfCheck =
     taskKey[Unit]("Check that the published archives ship the assembly LICENSE and NOTICE files in META-INF")
+
+  /**
+   * Text that has to appear in the shipped files. Matching the curated file byte for byte only says
+   * the merge strategy picked our copy; these markers say that copy is still the file it should be,
+   * and not one that has been emptied or truncated.
+   */
+  private val requiredContent = Map(
+    "META-INF/LICENSE" -> Seq(
+      "Apache License",
+      "Version 2.0, January 2004",
+      "TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION",
+      // the 3rd party section this file exists for, see legal/AssemblyLicense.txt
+      "contain classes from 3rd party projects",
+      "Apache License Version 2.0:"),
+    "META-INF/NOTICE" -> Seq(
+      "Apache Pekko gRPC",
+      "The Apache Software Foundation",
+      // the 3rd party section this file exists for, see legal/AssemblyNotice.txt
+      "contain classes from 3rd party projects"))
 
   /** A module id as listed in the assembly LICENSE file: `organization:name`, optionally `:version`. */
   private val ModuleId = """^([a-zA-Z0-9][\w.\-]*):([a-zA-Z0-9][\w.\-]*)(?::.*)?$""".r
@@ -97,8 +117,13 @@ object AssemblyLicenseCheck {
                     Some(s"$path is missing, expected a copy of $file")
                   case Some(entry) =>
                     val actual = Using.zipEntry(zip)(entry)(_.readAllBytes())
-                    if (actual.sameElements(IO.readBytes(file))) None
-                    else Some(s"$path does not match $file")
+                    if (!actual.sameElements(IO.readBytes(file))) Some(s"$path does not match $file")
+                    else {
+                      val text = new String(actual, StandardCharsets.UTF_8)
+                      val absent = requiredContent.getOrElse(path, Nil).filterNot(text.contains)
+                      if (absent.isEmpty) None
+                      else Some(s"$path does not mention ${absent.map(marker => s"'$marker'").mkString(", ")}")
+                    }
                 }
               }
             }

--- a/project/AssemblyLicenseCheck.scala
+++ b/project/AssemblyLicenseCheck.scala
@@ -48,7 +48,7 @@ object AssemblyLicenseCheck {
   /** A module id as listed in the assembly LICENSE file: `organization:name`, optionally `:version`. */
   private val ModuleId = """^([a-zA-Z0-9][\w.\-]*):([a-zA-Z0-9][\w.\-]*)(?::.*)?$""".r
 
-  lazy val settings: Seq[Setting[_]] = Seq(
+  lazy val settings: Seq[Setting[?]] = Seq(
     assemblyBundledModules := {
       val suffix = "_" + CrossVersion.binaryScalaVersion(scalaVersion.value)
       val modules = (assembly / fullClasspath).value.flatMap(_.get(moduleID.key))

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -110,6 +110,10 @@ object Dependencies {
     Compile.grpcProtobuf,
     Test.scalaTest)
 
+  lazy val scalapbProtocPlugin = l ++= Seq(
+    Compile.scalapbCompilerPlugin,
+    Protobuf.protobufJava) // or else scalapb pulls older version in transitively
+
   lazy val runtime = l ++= Seq(
     Compile.scalapbRuntime,
     Protobuf.protobufJava, // or else scalapb pulls older version in transitively


### PR DESCRIPTION
### Motivation

`pekko-grpc-codegen` and `pekko-grpc-scalapb-protoc-plugin` publish assembly jars and bat archives that bundle classes from 3rd party projects, so their `META-INF/LICENSE` and `META-INF/NOTICE` have to account for those projects. `legal/AssemblyLicense.txt` and `legal/AssemblyNotice.txt` exist for that, but:

- The codegen assembly jar and bat shipped **no `META-INF/LICENSE` at all**. The merge strategy discarded `META-INF/LICENSE` to stop guava/failureaccess colliding, and that also discarded the copy the `ApacheSonatypePlugin` resource generator puts in the jar.
- `legal/AssemblyLicense.txt` had drifted from what is actually bundled. It listed `org.checkerframework:checker-qual`, which guava dropped in favour of `org.jspecify:jspecify`, and jspecify was not listed anywhere.
- The scalapb-protoc-plugin assembly bundled protobuf-java 4.35.0, pulled in transitively by `compilerplugin`, rather than the pinned 4.36.0 that codegen and runtime bundle.

Nothing failed the build when the legal files fell behind a dependency change.

### Modification

- Merge `META-INF/LICENSE` and `META-INF/NOTICE` with `MergeStrategy.preferProject` in both assemblies, so our own files win over the ones the dependencies bring in.
- Swap `checker-qual` for `jspecify` in `legal/AssemblyLicense.txt` and drop the MIT text that was only there for checker-qual.
- Pin protobuf-java in scalapb-protoc-plugin via a new `Dependencies` group, the same way codegen and runtime already do.
- Add `project/AssemblyLicenseCheck.scala` with two tasks, wired into both assembly projects and run in CI as the `checkAssemblyLicenses` alias:
  - `assemblyLicenseCheck` fails when a module on the assembly classpath is not named in the assembly LICENSE file, and warns about listed modules that are not bundled for the Scala version being built (the assemblies are cross built, so e.g. `scala3-library` is legitimately absent from a 2.12 run).
  - `assemblyMetaInfCheck` opens the published assembly jar and bat archive and fails unless each carries `META-INF/LICENSE` and `META-INF/NOTICE` matching the files in `legal/`.

The LICENSE and NOTICE stay hand curated, which is what the ASF wants: only 1 of the ~20 bundled jars ships a `META-INF/NOTICE` of its own, so the text has to come from the upstream projects. The new tasks guard the curation rather than replace it.

### Result

Both assembly jars and both bat archives ship a LICENSE and NOTICE covering the 3rd party classes they bundle, both bundle protobuf-java 4.36.0, and CI fails if a dependency change leaves the legal files behind.

### Tests

- `sbt checkAssemblyLicenses` - passed. `assemblyMetaInfCheck` fails on the codegen assembly before the merge strategy fix (`META-INF/LICENSE` is missing), and `assemblyLicenseCheck` fails before the `AssemblyLicense.txt` fix (`org.jspecify:jspecify` is not accounted for).
- `sbt scalafmtSbtCheck` - passed.

### References

None - assembly jar license completeness
