### PR TITLE
Report malformed response headers as a gRPC status

### DIFF
--- a/runtime/src/main/scala/org/apache/pekko/grpc/internal/PekkoHttpClientUtils.scala
+++ b/runtime/src/main/scala/org/apache/pekko/grpc/internal/PekkoHttpClientUtils.scala
@@ -41,6 +41,7 @@ import scala.concurrent.{ ExecutionContext, Future, Promise }
 import scala.concurrent.duration.DurationLong
 import scala.jdk.FutureConverters._
 import scala.util.{ Failure, Success }
+import scala.util.control.NonFatal
 
 /**
  * INTERNAL API
@@ -382,7 +383,7 @@ object PekkoHttpClientUtils {
 
   private def mapToStatusException(response: HttpResponse, trailers: Seq[HttpHeader]): StatusRuntimeException = {
     val allHeaders = response.headers ++ trailers
-    val metadata: io.grpc.Metadata = new MetadataImpl(new HeaderMetadataImpl(allHeaders).asList).toGoogleGrpcMetadata()
+    val metadata: io.grpc.Metadata = metadataOf(allHeaders)
     allHeaders.find(_.name == "grpc-status").map(_.value) match {
       case None =>
         new StatusRuntimeException(mapHttpStatus(response).withDescription("No grpc-status found"), metadata)
@@ -391,9 +392,37 @@ object PekkoHttpClientUtils {
         // before it reaches the caller. The server side encodes it in `Status-Message`.
         val description =
           allHeaders.find(_.name == "grpc-message").map(h => PercentEncoding.Decoder.decode(h.value))
-        new StatusRuntimeException(Status.fromCodeValue(statusCode.toInt).withDescription(description.orNull), metadata)
+        statusCodeOf(statusCode) match {
+          case Some(code) =>
+            new StatusRuntimeException(Status.fromCodeValue(code).withDescription(description.orNull), metadata)
+          case None =>
+            // a peer that sends a non-numeric grpc-status is broken, but that is a protocol
+            // error to report, not an exception to throw at the caller
+            new StatusRuntimeException(
+              Status.INTERNAL.withDescription(s"Invalid grpc-status [$statusCode] in response"),
+              metadata)
+        }
     }
   }
+
+  /**
+   * The response metadata, or empty metadata if a header cannot be represented.
+   *
+   * Binary headers are base64-decoded here, which throws on a malformed value. That is
+   * reachable from any peer, and it happens while building the metadata for an error that is
+   * already being reported, so it must not replace that error with an exception of its own.
+   */
+  private def metadataOf(allHeaders: Seq[HttpHeader]): io.grpc.Metadata =
+    try new MetadataImpl(new HeaderMetadataImpl(allHeaders).asList).toGoogleGrpcMetadata()
+    catch {
+      case NonFatal(_) => new io.grpc.Metadata()
+    }
+
+  private def statusCodeOf(value: String): Option[Int] =
+    try Some(value.toInt)
+    catch {
+      case _: NumberFormatException => None
+    }
 
   /**
    * See https://github.com/grpc/grpc/blob/master/doc/http-grpc-status-mapping.md

--- a/runtime/src/test/scala/org/apache/pekko/grpc/internal/PekkoHttpClientUtilsSpec.scala
+++ b/runtime/src/test/scala/org/apache/pekko/grpc/internal/PekkoHttpClientUtilsSpec.scala
@@ -103,6 +103,38 @@ class PekkoHttpClientUtilsSpec extends TestKit(ActorSystem()) with AnyWordSpecLi
       failure.asInstanceOf[StatusRuntimeException].getStatus.getDescription should be("broken %ZZ escape")
     }
 
+    "report a non-numeric grpc-status as INTERNAL rather than throwing" in {
+      // a broken peer must not surface as a NumberFormatException to the caller
+      val responseHeaders = RawHeader("grpc-status", "abc") :: Nil
+      val response =
+        Future.successful(HttpResponse(OK, responseHeaders, Strict(GrpcProtocolNative.contentType, ByteString.empty)))
+
+      val failure = PekkoHttpClientUtils.responseToSource(response, null).run().failed.futureValue
+
+      failure shouldBe a[StatusRuntimeException]
+      val status = failure.asInstanceOf[StatusRuntimeException].getStatus
+      status.getCode should be(Status.Code.INTERNAL)
+      status.getDescription should include("abc")
+    }
+
+    "still report the gRPC status when a binary header is not valid base64" in {
+      // building the metadata base64-decodes `-bin` headers, which throws on a malformed value.
+      // That must not replace the error already being reported with an exception of its own.
+      val responseHeaders = RawHeader("grpc-status", "9") ::
+        RawHeader("grpc-message", "the real failure") ::
+        RawHeader("custom-key-bin", "!!!not valid base64!!!") ::
+        Nil
+      val response =
+        Future.successful(HttpResponse(OK, responseHeaders, Strict(GrpcProtocolNative.contentType, ByteString.empty)))
+
+      val failure = PekkoHttpClientUtils.responseToSource(response, null).run().failed.futureValue
+
+      failure shouldBe a[StatusRuntimeException]
+      val status = failure.asInstanceOf[StatusRuntimeException].getStatus
+      status.getCode should be(Status.Code.FAILED_PRECONDITION)
+      status.getDescription should be("the real failure")
+    }
+
     "map a strict 200 response with non-0 gRPC error code with a trailer to a failed stream with trailer metadata" in {
       val responseHeaders = List(RawHeader("grpc-status", "9"))
       val responseTrailers = Trailer(


### PR DESCRIPTION
### Motivation

Two spots in the pekko-http client turned a malformed response from the peer into
a raw JVM exception rather than a `StatusRuntimeException`, so a caller matching
on gRPC status saw something it could not handle.

```scala
Status.fromCodeValue(statusCode.toInt)  // NumberFormatException on `grpc-status: abc`
```

and, one line above it, building the response metadata base64-decodes every
`-bin` header:

```scala
new MetadataImpl(new HeaderMetadataImpl(allHeaders).asList).toGoogleGrpcMetadata()
// IllegalArgumentException: Illegal base64 character 21
```

`mapToStatusException` builds that metadata for *every* error response, so a
single invalid binary header replaced the error actually being reported with an
exception about itself.

Both are reachable from any peer. Confirmed against `main` before fixing:

```
grpc-status: abc          => java.lang.NumberFormatException: For input string: "abc"
custom-key-bin: !!!bad!!! => java.lang.IllegalArgumentException: Illegal base64 character 21
```

The netty backend rejects these at the transport layer, so this is pekko-http only.

### Modification

- A non-numeric `grpc-status` is reported as `INTERNAL`, quoting the offending
  value. `parseResponseStatus` already matches on `Some("0")`, so such a response
  was on the failure path regardless — it now fails with a status instead of an
  exception.
- Metadata construction falls back to empty metadata if a header cannot be
  represented, so the status and message still reach the caller.

### Result

A broken or hostile peer produces a `StatusRuntimeException` like any other
failure, instead of an exception the caller is not expecting.

### Tests

- 2 cases in `PekkoHttpClientUtilsSpec`: a non-numeric `grpc-status`, and a
  malformed `-bin` header alongside a real error that must still be reported

Confirmed both guards bite, by reverting each fix in turn:

- `toInt` restored → the non-numeric case fails
- metadata fallback removed → the base64 case fails

- `sbt "runtime/testOnly ...PekkoHttpClientUtilsSpec"` — 8 passed
- `sbt "runtime/mimaReportBinaryIssues"` — passed
- `sbt scalafmtAll scalafmtSbt` — applied
- `sbt "runtime/test"` (full suite) — not run locally, left to CI

### Notes

`HeaderMetadataImpl.getBinary` and `asList` still throw on a malformed binary
header when a user calls them directly on a successful response. Left as is: an
explicit accessor call is a different contract from the error path, where the
exception displaces an unrelated failure. Worth a separate look if we want the
accessors to be total.
