### PR TITLE
Add a config to stop grpc-web CORS allowing credentials from any origin

### DIFF
--- a/docs/src/main/paradox/server/grpc-web.md
+++ b/docs/src/main/paradox/server/grpc-web.md
@@ -49,3 +49,50 @@ Scala
 
 Java
 :  @@snip [Main.java](/plugin-tester-java/src/main/java/example/myapp/CombinedServer.java) { #grpc-web }
+
+## CORS and credentials
+
+@@@ warning
+
+`WebHandler.defaultCorsSettings` allows **any** origin and sets
+`Access-Control-Allow-Credentials: true`. A browser will therefore send cookies and HTTP
+authentication on a cross-origin call to your service, and let the calling page read the
+response. For a service authenticated that way, any web page your users visit can act as
+them — a CSRF vector.
+
+@@@
+
+Restrict the origins that may use credentials:
+
+Scala
+:   ```scala
+    import org.apache.pekko.http.cors.scaladsl.model.HttpOriginMatcher
+    import org.apache.pekko.http.scaladsl.model.headers.HttpOrigin
+
+    implicit val corsSettings: CorsSettings =
+      WebHandler.defaultCorsSettings
+        .withAllowedOrigins(HttpOriginMatcher(HttpOrigin("https://example.com")))
+    ```
+
+Java
+:   ```java
+    CorsSettings corsSettings = WebHandler.defaultCorsSettings()
+        .withAllowedOrigins(HttpOriginMatcher.create(HttpOrigin.parse("https://example.com")));
+    ```
+
+If your service does not need credentials at all, drop the permission instead:
+
+```hocon
+pekko.grpc.server.grpc-web {
+  allow-credentials-from-any-origin = false
+}
+```
+
+That makes the handler answer with `Access-Control-Allow-Origin: *` and no
+`Access-Control-Allow-Credentials`, so browsers withhold cookies on cross-origin calls. It
+defaults to `true`, preserving the existing behaviour; while it is `true` and the origins are
+unrestricted, a warning is logged for each handler created. Restricting the origins silences
+the warning and keeps credentials working.
+
+`reference.conf`
+:  @@snip [reference](/runtime/src/main/resources/reference.conf) { #grpc-web-cors }

--- a/runtime/src/main/resources/reference.conf
+++ b/runtime/src/main/resources/reference.conf
@@ -78,3 +78,23 @@ pekko.grpc.server {
   max-inbound-message-size = 4194304
 }
 //#server-defaults
+
+//#grpc-web-cors
+pekko.grpc.server.grpc-web {
+  # Whether `WebHandler.defaultCorsSettings` may send `Access-Control-Allow-Credentials: true`
+  # together with an origin the caller did not restrict.
+  #
+  # The default CORS settings allow any origin. Combined with credentials, that lets any web
+  # page make credentialed cross-origin gRPC-Web calls to your service and read the responses,
+  # which is a CSRF vector for anything authenticated by cookies or HTTP auth.
+  #
+  # true (the default) keeps the existing behaviour and logs a warning when the unsafe
+  # combination is actually in effect. Set it to false to drop the credentials permission,
+  # which makes browsers withhold cookies on cross-origin calls.
+  #
+  # To keep credentials safely, leave this at true and restrict the origins instead:
+  #   WebHandler.defaultCorsSettings.withAllowedOrigins(HttpOriginMatcher(HttpOrigin("https://example.com")))
+  # No warning is logged once the origins are restricted.
+  allow-credentials-from-any-origin = true
+}
+//#grpc-web-cors

--- a/runtime/src/main/scala/org/apache/pekko/grpc/javadsl/WebHandler.scala
+++ b/runtime/src/main/scala/org/apache/pekko/grpc/javadsl/WebHandler.scala
@@ -22,6 +22,7 @@ import pekko.actor.ClassicActorSystemProvider
 import pekko.annotation.ApiMayChange
 import pekko.grpc.javadsl.ServiceHandler.{ concatOrNotFound, unsupportedMediaType }
 import pekko.http.cors.javadsl.settings.CorsSettings
+import pekko.http.cors.scaladsl.settings.{ CorsSettings => sCorsSettings }
 import pekko.http.cors.javadsl.CorsDirectives
 import pekko.http.javadsl.marshalling.Marshaller
 import pekko.http.javadsl.model.{ HttpRequest, HttpResponse }
@@ -79,7 +80,13 @@ object WebHandler {
 
     val servicesHandler = concatOrNotFound(handlers.asScala.toList *)
     val servicesRoute = RouteAdapter(MarshallingDirectives.handleWith(servicesHandler.apply(_)))
-    val handler = asyncHandler(CorsDirectives.cors(corsSettings, () => servicesRoute), as, mat)
+    // scaladsl.CorsSettings extends the javadsl one, and every settings instance in practice is
+    // a scaladsl one, so this reaches the credentials policy without a javadsl-side conversion
+    val settings = corsSettings match {
+      case s: sCorsSettings => scaladsl.WebHandler.withCredentialsPolicy(s, as.classicSystem)
+      case other            => other
+    }
+    val handler = asyncHandler(CorsDirectives.cors(settings, () => servicesRoute), as, mat)
     (req: HttpRequest) =>
       if (scaladsl.ServiceHandler.isGrpcWebRequest(req) /*|| scaladsl.WebHandler.isCorsPreflightRequest(req)*/ )
         handler(req)

--- a/runtime/src/main/scala/org/apache/pekko/grpc/scaladsl/WebHandler.scala
+++ b/runtime/src/main/scala/org/apache/pekko/grpc/scaladsl/WebHandler.scala
@@ -18,9 +18,9 @@ import scala.concurrent.Future
 import com.typesafe.config.ConfigFactory
 import org.apache.pekko
 import pekko.actor.{ ActorSystem, ClassicActorSystemProvider }
-import pekko.annotation.ApiMayChange
+import pekko.annotation.{ ApiMayChange, InternalApi }
 import pekko.http.cors.scaladsl.CorsDirectives.cors
-import pekko.http.cors.scaladsl.model.HttpHeaderRange
+import pekko.http.cors.scaladsl.model.{ HttpHeaderRange, HttpOriginMatcher }
 import pekko.http.cors.scaladsl.settings.CorsSettings
 import pekko.http.javadsl.{ model => jmodel }
 import pekko.http.scaladsl.model.{ HttpMethods, HttpRequest, HttpResponse }
@@ -31,7 +31,19 @@ import pekko.http.scaladsl.server.directives.MarshallingDirectives.handleWith
 @ApiMayChange
 object WebHandler {
 
-  /** Default CORS settings to use for grpc-web */
+  /**
+   * Default CORS settings to use for grpc-web.
+   *
+   * These allow credentials from any origin, which lets any web page make credentialed
+   * cross-origin calls to your service and read the responses. Restrict the origins for
+   * anything authenticated by cookies or HTTP auth:
+   *
+   * {{{
+   * WebHandler.defaultCorsSettings.withAllowedOrigins(HttpOriginMatcher(HttpOrigin("https://example.com")))
+   * }}}
+   *
+   * See `pekko.grpc.server.grpc-web.allow-credentials-from-any-origin`.
+   */
   val defaultCorsSettings: CorsSettings = CorsSettings(ConfigFactory.load())
     .withAllowCredentials(true)
     .withAllowedMethods(immutable.Seq(HttpMethods.POST, HttpMethods.OPTIONS))
@@ -44,6 +56,44 @@ object WebHandler {
         Accept.name,
         "grpc-timeout",
         `Accept-Encoding`.name))
+
+  /**
+   * INTERNAL API
+   *
+   * Whether `settings` permits credentialed requests from origins the caller has not restricted.
+   *
+   * `HttpOriginMatcher.*` is the wildcard the `allowed-origins = "*"` default parses to. A
+   * matcher listing origins is a deliberate choice and is not reported, even though a listed
+   * entry may itself contain a `*.` subdomain wildcard.
+   */
+  @InternalApi
+  private[grpc] def allowsCredentialsFromAnyOrigin(settings: CorsSettings): Boolean =
+    settings.allowCredentials && (settings.allowedOrigins eq HttpOriginMatcher.`*`)
+
+  /**
+   * INTERNAL API
+   *
+   * Applies `pekko.grpc.server.grpc-web.allow-credentials-from-any-origin` to `settings`.
+   *
+   * When the setting is off the credentials permission is dropped, so browsers withhold
+   * cookies on cross-origin calls. When it is on the settings are returned unchanged and the
+   * combination is logged, because it is only reachable by a peer we cannot vouch for.
+   */
+  @InternalApi
+  private[grpc] def withCredentialsPolicy(settings: CorsSettings, system: ActorSystem): CorsSettings =
+    if (!allowsCredentialsFromAnyOrigin(settings)) settings
+    else if (system.settings.config.getBoolean(AllowCredentialsFromAnyOriginPath)) {
+      system.log.warning(
+        "grpc-web CORS allows credentials from any origin, so any web page can make " +
+        "credentialed cross-origin calls to this service and read the responses. Restrict the " +
+        "origins with CorsSettings.withAllowedOrigins, or set {} = false to drop the " +
+        "credentials permission.",
+        AllowCredentialsFromAnyOriginPath)
+      settings
+    } else settings.withAllowCredentials(false)
+
+  private val AllowCredentialsFromAnyOriginPath =
+    "pekko.grpc.server.grpc-web.allow-credentials-from-any-origin"
 
   private[grpc] def isCorsPreflightRequest(r: jmodel.HttpRequest): Boolean =
     r.method == HttpMethods.OPTIONS && r.getHeader(classOf[Origin]).isPresent &&
@@ -64,7 +114,7 @@ object WebHandler {
       corsSettings: CorsSettings = defaultCorsSettings): HttpRequest => Future[HttpResponse] = {
     implicit val system: ActorSystem = as.classicSystem
     val servicesHandler = ServiceHandler.concat(handlers *)
-    Route.toFunction(cors(corsSettings) {
+    Route.toFunction(cors(withCredentialsPolicy(corsSettings, system)) {
       handleWith(servicesHandler)
     })
   }

--- a/runtime/src/test/scala/org/apache/pekko/grpc/scaladsl/WebHandlerCorsSpec.scala
+++ b/runtime/src/test/scala/org/apache/pekko/grpc/scaladsl/WebHandlerCorsSpec.scala
@@ -60,9 +60,9 @@ class WebHandlerCorsSpec
         .withFallback(ConfigFactory.load()))
 
   private def respond(sys: ActorSystem, settings: CorsSettings, request: HttpRequest): HttpResponse = {
-    val handler = WebHandler.grpcWebHandler({
+    val handler = WebHandler.grpcWebHandler {
       case _: HttpRequest => Future.successful(HttpResponse())
-    })(sys, settings)
+    }(sys, settings)
     handler(request).futureValue
   }
 

--- a/runtime/src/test/scala/org/apache/pekko/grpc/scaladsl/WebHandlerCorsSpec.scala
+++ b/runtime/src/test/scala/org/apache/pekko/grpc/scaladsl/WebHandlerCorsSpec.scala
@@ -1,0 +1,151 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.pekko.grpc.scaladsl
+
+import scala.concurrent.Future
+import scala.concurrent.duration._
+
+import com.typesafe.config.ConfigFactory
+import org.apache.pekko
+import pekko.actor.ActorSystem
+import pekko.http.cors.scaladsl.model.HttpOriginMatcher
+import pekko.http.cors.scaladsl.settings.CorsSettings
+import pekko.http.scaladsl.model._
+import pekko.http.scaladsl.model.headers._
+import pekko.testkit.TestKit
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.time.Span
+import org.scalatest.wordspec.AnyWordSpecLike
+
+/**
+ * `defaultCorsSettings` allows any origin and sets `Access-Control-Allow-Credentials: true`,
+ * so a browser will send cookies on a cross-origin call and let the calling page read the
+ * response. `allow-credentials-from-any-origin = false` drops the credentials permission.
+ */
+class WebHandlerCorsSpec
+    extends TestKit(ActorSystem("WebHandlerCorsSpec"))
+    with AnyWordSpecLike
+    with Matchers
+    with ScalaFutures
+    with BeforeAndAfterAll {
+
+  implicit val patience: PatienceConfig =
+    PatienceConfig(5.seconds, Span(100, org.scalatest.time.Millis))
+
+  private val foreignOrigin = HttpOrigin("https://evil.example")
+
+  private def systemWith(allowCredentialsFromAnyOrigin: Boolean): ActorSystem =
+    ActorSystem(
+      "configured",
+      ConfigFactory
+        .parseString(
+          s"pekko.grpc.server.grpc-web.allow-credentials-from-any-origin = $allowCredentialsFromAnyOrigin")
+        .withFallback(ConfigFactory.load()))
+
+  private def respond(sys: ActorSystem, settings: CorsSettings, request: HttpRequest): HttpResponse = {
+    val handler = WebHandler.grpcWebHandler({
+      case _: HttpRequest => Future.successful(HttpResponse())
+    })(sys, settings)
+    handler(request).futureValue
+  }
+
+  private def actualRequest =
+    HttpRequest(HttpMethods.POST, "/foo.Service/Method").withHeaders(Origin(foreignOrigin))
+
+  private def preflightRequest =
+    HttpRequest(HttpMethods.OPTIONS, "/foo.Service/Method")
+      .withHeaders(Origin(foreignOrigin), `Access-Control-Request-Method`(HttpMethods.POST))
+
+  private def allowCredentials(response: HttpResponse): Boolean =
+    response.headers.exists(h => h.is("access-control-allow-credentials") && h.value == "true")
+
+  private def allowOrigin(response: HttpResponse): Option[String] =
+    response.headers.collectFirst { case h if h.is("access-control-allow-origin") => h.value }
+
+  "The default grpc-web CORS settings" should {
+
+    "be reported as allowing credentials from any origin" in {
+      WebHandler.allowsCredentialsFromAnyOrigin(WebHandler.defaultCorsSettings) shouldBe true
+    }
+
+    "not be reported once the origins are restricted" in {
+      val restricted =
+        WebHandler.defaultCorsSettings.withAllowedOrigins(HttpOriginMatcher(HttpOrigin("https://good.example")))
+
+      WebHandler.allowsCredentialsFromAnyOrigin(restricted) shouldBe false
+    }
+
+    "not be reported when credentials are not allowed" in {
+      WebHandler.allowsCredentialsFromAnyOrigin(
+        WebHandler.defaultCorsSettings.withAllowCredentials(false)) shouldBe false
+    }
+  }
+
+  "With allow-credentials-from-any-origin = true (the default)" should {
+    lazy val sys = systemWith(allowCredentialsFromAnyOrigin = true)
+
+    "echo a foreign origin and allow credentials, as before" in {
+      val response = respond(sys, WebHandler.defaultCorsSettings, actualRequest)
+
+      allowOrigin(response) shouldBe Some(foreignOrigin.value)
+      allowCredentials(response) shouldBe true
+    }
+
+    "allow credentials on the preflight too" in {
+      val response = respond(sys, WebHandler.defaultCorsSettings, preflightRequest)
+
+      allowCredentials(response) shouldBe true
+    }
+  }
+
+  "With allow-credentials-from-any-origin = false" should {
+    lazy val sys = systemWith(allowCredentialsFromAnyOrigin = false)
+
+    "not allow credentials to a foreign origin" in {
+      val response = respond(sys, WebHandler.defaultCorsSettings, actualRequest)
+
+      allowCredentials(response) shouldBe false
+      // the wildcard is what makes a browser withhold cookies rather than send them
+      allowOrigin(response) shouldBe Some("*")
+    }
+
+    "not allow credentials on the preflight either" in {
+      val response = respond(sys, WebHandler.defaultCorsSettings, preflightRequest)
+
+      allowCredentials(response) shouldBe false
+    }
+
+    "leave settings that restrict the origins alone" in {
+      // credentials are safe once the caller has said which origins may use them, so the
+      // setting must not take them away
+      val restricted =
+        WebHandler.defaultCorsSettings.withAllowedOrigins(HttpOriginMatcher(foreignOrigin))
+      val response = respond(sys, restricted, actualRequest)
+
+      allowCredentials(response) shouldBe true
+      allowOrigin(response) shouldBe Some(foreignOrigin.value)
+    }
+  }
+
+  override def afterAll(): Unit = {
+    TestKit.shutdownActorSystem(system)
+    super.afterAll()
+  }
+}


### PR DESCRIPTION
### Motivation

`WebHandler.defaultCorsSettings` sets `withAllowCredentials(true)` and leaves
`allowed-origins` at the pekko-http-cors reference default of `"*"`. A POST from
an arbitrary origin is answered with:

```
Access-Control-Allow-Origin: https://evil.example
Access-Control-Allow-Credentials: true
```

so a browser sends cookies and HTTP authentication on a cross-origin call and
lets the calling page read the response. For a service authenticated that way,
any page a user visits can act as them — a CSRF vector.

Verified against `main` before changing anything; the output above is what the
current default actually returns. Note there is no backend to switch to that
avoids this: grpc-netty in this repo is client-only, so every gRPC-Web
deployment is served by pekko-http through these settings.

### Modification

Added `pekko.grpc.server.grpc-web.allow-credentials-from-any-origin`, default
`true`, so existing deployments are unchanged. While it is `true` and the
combination is actually in effect, each handler logs a warning naming the two
ways out.

Set it to `false` and the credentials permission is dropped — the handler
answers `Access-Control-Allow-Origin: *` with no `Access-Control-Allow-Credentials`,
which is what makes browsers withhold cookies on cross-origin calls.

The check tests `HttpOriginMatcher.*` by identity, which is what
`allowed-origins = "*"` parses to. Settings that list origins are a deliberate
choice, so they are neither warned about nor modified — credentials keep working
once the caller has said who may use them.

Both entry points are covered. The javadsl handler builds its own CORS route and
would otherwise have bypassed this; `scaladsl.CorsSettings` extends the javadsl
one, so it reaches the same policy through a match.

### Result

The insecure combination is reported wherever it is live, and can be switched off
with configuration rather than a code change. The default is unchanged behaviour.

### Tests

`WebHandlerCorsSpec` asserts the response headers in both modes, for actual and
preflight requests:

| setting | `Allow-Origin` | `Allow-Credentials` |
|---|---|---|
| `true` (default) | echoes the caller's origin | `true` |
| `false` | `*` | absent |
| `false`, origins restricted | the restricted origin | `true` |

Confirmed the guard bites: not applying the policy fails 2 tests.

- `sbt "runtime/testOnly ...WebHandlerCorsSpec"` — 8 passed
- `sbt "runtime/mimaReportBinaryIssues"` — passed
- `sbt docs/paradox` — passed
- `sbt scalafmtAll scalafmtSbt` — applied
- `sbt "runtime/test"` (full suite) — not run locally, left to CI

### Notes

The default is deliberately left at the insecure-but-compatible value, per
maintainer direction: this ships as an opt-in with a warning rather than a
breaking change. Flipping the default to `false` would be the stronger fix and
is worth considering for a major version, since `WebHandler` is `@ApiMayChange`
and gRPC-Web is documented as experimental.
