### PR TITLE
Honour grpc-timeout on the server, and send it from the pekko-http client

### DIFF
--- a/codegen/src/main/twirl/templates/JavaServer/Handler.scala.txt
+++ b/codegen/src/main/twirl/templates/JavaServer/Handler.scala.txt
@@ -179,6 +179,15 @@ public class @{serviceName}HandlerFactory {
 
     private static CompletionStage<org.apache.pekko.http.javadsl.model.HttpResponse> handle(org.apache.pekko.http.javadsl.model.HttpRequest request, String method, @serviceName implementation, Materializer mat, org.apache.pekko.japi.function.Function<ActorSystem, org.apache.pekko.japi.function.Function<Throwable, Trailers>> eHandler, int maxInboundMessageSize, ClassicActorSystemProvider system) {
       return GrpcMarshalling.negotiatedWithMaxSize(request, maxInboundMessageSize, (reader, writer) -> {
+        // the client stops waiting once its deadline expires; without this the server keeps
+        // working on a reply nobody is going to read
+        return GrpcMarshalling.withServerDeadline(request, negotiate(request, method, implementation, mat, eHandler, system, reader, writer), system, writer);
+      })
+      .orElseGet(() -> unsupportedMediaType);
+    }
+
+    private static CompletionStage<org.apache.pekko.http.javadsl.model.HttpResponse> negotiate(org.apache.pekko.http.javadsl.model.HttpRequest request, String method, @serviceName implementation, Materializer mat, org.apache.pekko.japi.function.Function<ActorSystem, org.apache.pekko.japi.function.Function<Throwable, Trailers>> eHandler, ClassicActorSystemProvider system, org.apache.pekko.grpc.GrpcProtocol.GrpcProtocolReader reader, org.apache.pekko.grpc.GrpcProtocol.GrpcProtocolWriter writer) {
+      {
         CompletionStage<org.apache.pekko.http.javadsl.model.HttpResponse> response;
         @{if(powerApis) { "Metadata metadata = MetadataBuilder.fromHeaders(request.getHeaders());" } else { "" }}
         switch(method) {
@@ -222,8 +231,7 @@ public class @{serviceName}HandlerFactory {
             response = result;
         }
         return response.exceptionally(e -> GrpcExceptionHandler.standard(e, eHandler, writer, system));
-      })
-      .orElseGet(() -> unsupportedMediaType);
+      }
     }
   }
 }

--- a/codegen/src/main/twirl/templates/ScalaServer/Handler.scala.txt
+++ b/codegen/src/main/twirl/templates/ScalaServer/Handler.scala.txt
@@ -126,6 +126,9 @@ object @{serviceName}Handler {
 
       def handle(request: model.HttpRequest, method: String): scala.concurrent.Future[model.HttpResponse] =
         GrpcMarshalling.negotiatedWithMaxSize(request, maxInboundMessageSize, (reader, writer) =>
+          // the client stops waiting once its deadline expires; without this the server keeps
+          // working on a reply nobody is going to read
+          GrpcMarshalling.withServerDeadline(request,
           method match {
             @for(method <- service.methods) {
             case "@method.grpcName" =>
@@ -141,7 +144,7 @@ object @{serviceName}Handler {
                 }
             }
             case m => GrpcExceptionHandler.from(eHandler(system.classicSystem))(system, writer)(new NotImplementedError(s"Not implemented: $m"))
-          }
+          })(system, writer, ec)
       ).getOrElse(unsupportedMediaType)
 
       request => {
@@ -171,6 +174,9 @@ object @{serviceName}Handler {
 
       def handle(request: model.HttpRequest, method: String): scala.concurrent.Future[model.HttpResponse] =
         GrpcMarshalling.negotiatedWithMaxSize(request, maxInboundMessageSize, (reader, writer) =>
+          // the client stops waiting once its deadline expires; without this the server keeps
+          // working on a reply nobody is going to read
+          GrpcMarshalling.withServerDeadline(request,
           method match {
             @for(method <- service.methods) {
             case "@method.grpcName" =>
@@ -186,7 +192,7 @@ object @{serviceName}Handler {
                 }
             }
             case m => GrpcExceptionHandler.from(eHandler(system.classicSystem))(system, writer)(new NotImplementedError(s"Not implemented: $m"))
-          }
+          })(system, writer, ec)
       ).getOrElse(unsupportedMediaType)
 
       Function.unlift((req: model.HttpRequest) => {

--- a/docs/src/main/paradox/server/details.md
+++ b/docs/src/main/paradox/server/details.md
@@ -112,3 +112,36 @@ configuration, so they fall back on the 4 MiB default and `pekko.grpc.server.max
 has no effect on them. Regenerate your sources against 2.0.0 to make the setting apply.
 
 @@@
+
+## Deadlines
+
+A client can tell the server how long it is prepared to wait by sending the `grpc-timeout`
+request header. Generated handlers honour it: when the deadline passes before the service has
+replied, the call is completed with `DEADLINE_EXCEEDED` — the same status the client reports for
+the same call.
+
+Without this the server would keep working on a reply nobody is going to read, since the client
+stops waiting when its own deadline expires.
+
+Both clients send the header when a call has a deadline:
+
+Scala
+:   ```scala
+    import io.grpc.{ CallOptions, Deadline }
+    import java.util.concurrent.TimeUnit
+
+    val settings = GrpcClientSettings.connectToServiceAt("localhost", 8080)
+      .withDeadline(5.seconds)
+    ```
+
+@@@ note
+
+The deadline bounds the response, not the work behind it. A service that has already started an
+expensive operation keeps running it; only the reply is abandoned. To stop the work itself, have
+the service observe cancellation of the `Future` or `Source` it returned.
+
+@@@
+
+A request that carries no `grpc-timeout`, or one whose value is malformed, is served without a
+deadline. A malformed value is deliberately ignored rather than rejected: the timeout is a hint
+from the peer, and refusing the request outright would be a worse outcome than serving it.

--- a/plugin-tester-scala/src/test/scala/example/myapp/helloworld/ServerTimeoutSpec.scala
+++ b/plugin-tester-scala/src/test/scala/example/myapp/helloworld/ServerTimeoutSpec.scala
@@ -1,0 +1,117 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package example.myapp.helloworld
+
+import java.util.concurrent.atomic.AtomicBoolean
+
+import scala.concurrent.{ ExecutionContext, Future, Promise }
+import scala.concurrent.duration._
+
+import com.typesafe.config.ConfigFactory
+import example.myapp.helloworld.grpc._
+import io.grpc.Status
+import org.apache.pekko
+import pekko.actor.ActorSystem
+import pekko.grpc.scaladsl.headers.`Timeout`
+import pekko.http.scaladsl.model.{ HttpRequest, HttpResponse }
+import pekko.stream.scaladsl.Source
+import org.junit.runner.RunWith
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.time.Span
+import org.scalatest.wordspec.AnyWordSpecLike
+import org.scalatestplus.junit.JUnitRunner
+
+/**
+ * Drives a generated handler directly, so this covers the codegen wiring rather than only the
+ * `GrpcMarshalling` helper it calls.
+ */
+@RunWith(classOf[JUnitRunner])
+class ServerTimeoutSpec extends Matchers with AnyWordSpecLike with BeforeAndAfterAll with ScalaFutures {
+
+  implicit val patience: PatienceConfig = PatienceConfig(10.seconds, Span(50, org.scalatest.time.Millis))
+
+  implicit val system: ActorSystem = ActorSystem(
+    "ServerTimeoutSpec",
+    ConfigFactory
+      .parseString("pekko.http.server.enable-http2 = on")
+      .withFallback(ConfigFactory.defaultApplication()))
+
+  implicit val ec: ExecutionContext = system.dispatcher
+
+  /** A service whose reply never arrives, standing in for one that outlives the client. */
+  private class StuckGreeter(val entered: AtomicBoolean = new AtomicBoolean(false)) extends GreeterService {
+    override def sayHello(in: HelloRequest): Future[HelloReply] = {
+      entered.set(true)
+      Promise[HelloReply]().future
+    }
+    override def itKeepsTalking(in: Source[HelloRequest, pekko.NotUsed]): Future[HelloReply] =
+      Promise[HelloReply]().future
+    override def itKeepsReplying(in: HelloRequest): Source[HelloReply, pekko.NotUsed] = Source.empty
+    override def streamHellos(in: Source[HelloRequest, pekko.NotUsed]): Source[HelloReply, pekko.NotUsed] =
+      Source.empty
+  }
+
+  private implicit val writer: pekko.grpc.GrpcProtocol.GrpcProtocolWriter =
+    pekko.grpc.internal.GrpcProtocolNative.newWriter(pekko.grpc.internal.Identity)
+
+  private def request(timeout: Option[FiniteDuration]): HttpRequest =
+    pekko.grpc.internal.GrpcRequestHelpers(
+      pekko.http.scaladsl.model.Uri(s"http://localhost/${GreeterService.name}/SayHello"),
+      timeout.map(t => `Timeout`(t)).toList,
+      Source.single(HelloRequest("Alice")))(
+      GreeterService.Serializers.HelloRequestSerializer,
+      writer,
+      system)
+
+  private def statusOf(response: HttpResponse): Option[String] =
+    (response.headers ++ response.attribute(pekko.http.scaladsl.model.AttributeKeys.trailer).toSeq.flatMap(
+      _.headers.map { case (k, v) => pekko.http.scaladsl.model.headers.RawHeader(k, v) }))
+      .collectFirst { case h if h.is("grpc-status") => h.value }
+
+  "A generated handler" should {
+
+    "answer DEADLINE_EXCEEDED once the client's grpc-timeout expires" in {
+      val service = new StuckGreeter
+      val handler = GreeterServiceHandler(service)
+
+      val response = handler(request(Some(200.millis))).futureValue
+
+      withClue("the handler should have been entered, so this is the deadline and not a routing miss: ") {
+        service.entered.get() shouldBe true
+      }
+      statusOf(response) shouldBe Some(Status.Code.DEADLINE_EXCEEDED.value.toString)
+    }
+
+    "not answer early when the request carries no grpc-timeout" in {
+      val handler = GreeterServiceHandler(new StuckGreeter)
+
+      val response = handler(request(None))
+
+      // nothing bounds it, so it is still pending well after the deadline above would have hit
+      pekko.pattern.after(500.millis)(Future.successful(()))(system).futureValue
+      response.isCompleted shouldBe false
+    }
+  }
+
+  override def afterAll(): Unit = {
+    system.terminate()
+    super.afterAll()
+  }
+}

--- a/runtime/src/main/scala/org/apache/pekko/grpc/internal/PekkoHttpClientUtils.scala
+++ b/runtime/src/main/scala/org/apache/pekko/grpc/internal/PekkoHttpClientUtils.scala
@@ -23,6 +23,7 @@ import pekko.actor.ClassicActorSystemProvider
 import pekko.annotation.InternalApi
 import pekko.event.LoggingAdapter
 import pekko.grpc.GrpcProtocol.GrpcProtocolReader
+import pekko.grpc.scaladsl.headers
 import pekko.grpc.scaladsl.headers.PercentEncoding
 import pekko.grpc.{ GrpcClientSettings, GrpcResponseMetadata, GrpcSingleResponse, ProtobufSerializer }
 import pekko.http.scaladsl.model.HttpEntity.{ Chunk, Chunked, LastChunk, Strict }
@@ -38,7 +39,8 @@ import io.grpc.{ CallOptions, MethodDescriptor, Status, StatusRuntimeException }
 import javax.net.ssl.{ KeyManager, SSLContext, SSLEngine, TrustManager }
 import scala.collection.immutable
 import scala.concurrent.{ ExecutionContext, Future, Promise }
-import scala.concurrent.duration.DurationLong
+import scala.concurrent.duration.{ DurationLong, FiniteDuration }
+import java.util.concurrent.TimeUnit
 import scala.jdk.FutureConverters._
 import scala.util.{ Failure, Success }
 
@@ -185,7 +187,7 @@ object PekkoHttpClientUtils {
           Uri(
             s"${scheme}://${settings.overrideAuthority.getOrElse(settings.serviceName)}/" +
             descriptor.getFullMethodName),
-          GrpcEntityHelpers.metadataHeaders(headers.entries),
+          GrpcEntityHelpers.metadataHeaders(headers.entries) ++ timeoutHeader(options),
           source)
         applyDeadline(
           responseToSource(singleRequest(httpRequest), deserializer, settings.maxInboundMessageSize),
@@ -193,6 +195,26 @@ object PekkoHttpClientUtils {
       }
     }
   }
+
+  /**
+   * INTERNAL API
+   *
+   * The `grpc-timeout` header for a call, so the server can stop work the client has given up
+   * on. `applyDeadline` only bounds the wait on this side; without this header the server has
+   * no way to know there is a deadline at all.
+   *
+   * An expired deadline sends no header: `applyDeadline` fails such a call outright, and a
+   * zero or negative timeout is not representable on the wire.
+   */
+  @InternalApi
+  private[internal] def timeoutHeader(options: CallOptions): List[HttpHeader] =
+    Option(options.getDeadline) match {
+      case None           => Nil
+      case Some(deadline) =>
+        val remaining = deadline.timeRemaining(TimeUnit.NANOSECONDS)
+        if (remaining <= 0) Nil
+        else List(headers.`Timeout`(FiniteDuration(remaining, TimeUnit.NANOSECONDS)))
+    }
 
   /**
    * INTERNAL API

--- a/runtime/src/main/scala/org/apache/pekko/grpc/javadsl/GrpcMarshalling.scala
+++ b/runtime/src/main/scala/org/apache/pekko/grpc/javadsl/GrpcMarshalling.scala
@@ -67,6 +67,31 @@ object GrpcMarshalling {
       }
       .fold(Optional.empty[CompletionStage[T]])(Optional.of)
 
+  /**
+   * INTERNAL API
+   *
+   * Java API: bounds `response` by the deadline the client asked for in `grpc-timeout`.
+   *
+   * See the scaladsl `GrpcMarshalling.withServerDeadline`.
+   */
+  @InternalApi
+  def withServerDeadline(
+      request: HttpRequest,
+      response: CompletionStage[HttpResponse],
+      system: ClassicActorSystemProvider,
+      writer: GrpcProtocolWriter): CompletionStage[HttpResponse] = {
+    import scala.jdk.FutureConverters._
+    implicit val ec: scala.concurrent.ExecutionContext = system.classicSystem.dispatcher
+    val scalaRequest = request.asInstanceOf[pekko.http.scaladsl.model.HttpRequest]
+    scaladsl.GrpcMarshalling
+      .withServerDeadline(scalaRequest, response.asScala.map(_.asInstanceOf[pekko.http.scaladsl.model.HttpResponse]))(
+        system,
+        writer,
+        ec)
+      .map(r => r: HttpResponse)
+      .asJava
+  }
+
   def unmarshal[T](
       data: Source[ByteString, AnyRef],
       u: ProtobufSerializer[T],

--- a/runtime/src/main/scala/org/apache/pekko/grpc/scaladsl/GrpcMarshalling.scala
+++ b/runtime/src/main/scala/org/apache/pekko/grpc/scaladsl/GrpcMarshalling.scala
@@ -54,6 +54,33 @@ object GrpcMarshalling {
       }).getOrElse(throw new GrpcServiceException(Status.UNIMPLEMENTED))
   }
 
+  /**
+   * INTERNAL API
+   *
+   * Bounds `response` by the deadline the client asked for in `grpc-timeout`.
+   *
+   * The client stops waiting when its own deadline expires, but without this the server keeps
+   * working on a reply nobody will read. On expiry the call is completed with
+   * `DEADLINE_EXCEEDED`, matching what the client reports for the same call.
+   *
+   * A request with no `grpc-timeout`, or an unparseable one, is left unbounded.
+   */
+  @InternalApi
+  def withServerDeadline(request: HttpRequest, response: Future[HttpResponse])(
+      implicit system: ClassicActorSystemProvider,
+      writer: GrpcProtocolWriter,
+      ec: ExecutionContext): Future[HttpResponse] =
+    headers.`Timeout`.findIn(request.headers) match {
+      case None           => response
+      case Some(deadline) =>
+        val timedOut = pekko.pattern.after(deadline)(
+          FastFuture.successful(
+            GrpcResponseHelpers.status(
+              Trailers(Status.DEADLINE_EXCEEDED.withDescription(s"Deadline of $deadline exceeded")))))(
+          system.classicSystem)
+        Future.firstCompletedOf(List(response, timedOut))
+    }
+
   def negotiated[T](req: HttpRequest, f: (GrpcProtocolReader, GrpcProtocolWriter) => Future[T]): Option[Future[T]] =
     GrpcProtocol.negotiate(req).map {
       case (Success(reader), writer) => f(reader, writer)

--- a/runtime/src/main/scala/org/apache/pekko/grpc/scaladsl/headers/headers.scala
+++ b/runtime/src/main/scala/org/apache/pekko/grpc/scaladsl/headers/headers.scala
@@ -23,6 +23,8 @@ import scala.collection.compat.immutable.ArraySeq
 import scala.collection.immutable
 import scala.annotation.nowarn
 import scala.util.Try
+import scala.concurrent.duration.FiniteDuration
+import java.util.concurrent.TimeUnit
 
 /**
  * Simple CSV parser for HTTP header values. Not meant to be a full CSV parser,
@@ -106,6 +108,71 @@ object `Status` extends ModeledCustomHeaderCompanion[`Status`] {
 
   def findIn(headers: immutable.Seq[HttpHeader]): Option[Int] =
     headers.collectFirst { case h if h.is(name) => Integer.parseInt(h.value()) }
+}
+
+/**
+ * The `grpc-timeout` request header: how long the client is prepared to wait for a reply.
+ *
+ * The wire format is a positive integer of at most 8 digits followed by a unit character, as
+ * per https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md - `H`ours, `M`inutes,
+ * `S`econds, `m`illiseconds, `u`microseconds, `n`anoseconds.
+ */
+@ApiMayChange
+final class `Timeout`(val timeout: FiniteDuration) extends ModeledCustomHeader[`Timeout`] {
+  override def renderInRequests = true
+  override def renderInResponses = false
+  @nowarn("msg=the inferred type changes")
+  override val companion = `Timeout`
+
+  // Nanoseconds keep the value exact for any duration the client can express, but the field is
+  // capped at 8 digits, so fall back to coarser units as the value grows.
+  override def value(): String = {
+    val nanos = timeout.toNanos
+    if (nanos < `Timeout`.MaxValue) s"${nanos}n"
+    else if (timeout.toMicros < `Timeout`.MaxValue) s"${timeout.toMicros}u"
+    else if (timeout.toMillis < `Timeout`.MaxValue) s"${timeout.toMillis}m"
+    else if (timeout.toSeconds < `Timeout`.MaxValue) s"${timeout.toSeconds}S"
+    else if (timeout.toMinutes < `Timeout`.MaxValue) s"${timeout.toMinutes}M"
+    else s"${timeout.toHours}H"
+  }
+}
+
+@ApiMayChange
+object `Timeout` extends ModeledCustomHeaderCompanion[`Timeout`] {
+  override val name = "grpc-timeout"
+  override val lowercaseName: String = super.lowercaseName
+
+  /** The wire format allows at most 8 digits. */
+  private[grpc] final val MaxValue = 100000000L
+
+  def apply(timeout: FiniteDuration): `Timeout` = new `Timeout`(timeout)
+
+  override def parse(value: String): Try[`Timeout`] = Try {
+    require(value.length >= 2, s"Invalid grpc-timeout [$value]")
+    val digits = value.substring(0, value.length - 1)
+    require(digits.length <= 8, s"Invalid grpc-timeout [$value], at most 8 digits allowed")
+    val amount = digits.toLong
+    require(amount >= 0, s"Invalid grpc-timeout [$value], must not be negative")
+    val unit = value.charAt(value.length - 1) match {
+      case 'H'   => TimeUnit.HOURS
+      case 'M'   => TimeUnit.MINUTES
+      case 'S'   => TimeUnit.SECONDS
+      case 'm'   => TimeUnit.MILLISECONDS
+      case 'u'   => TimeUnit.MICROSECONDS
+      case 'n'   => TimeUnit.NANOSECONDS
+      case other => throw new IllegalArgumentException(s"Invalid grpc-timeout unit [$other] in [$value]")
+    }
+    new `Timeout`(FiniteDuration(amount, unit))
+  }
+
+  /**
+   * The timeout requested in these headers, if any.
+   *
+   * A malformed value yields `None` rather than failing the request: the timeout is a hint from
+   * the peer, and refusing to serve a request over it would be worse than ignoring it.
+   */
+  def findIn(headers: immutable.Seq[HttpHeader]): Option[FiniteDuration] =
+    headers.collectFirst { case h if h.is(name) => parse(h.value()).toOption.map(_.timeout) }.flatten
 }
 
 // grpc-message must be percent encoded: https://github.com/grpc/grpc/issues/4672

--- a/runtime/src/test/scala/org/apache/pekko/grpc/internal/ClientTimeoutHeaderSpec.scala
+++ b/runtime/src/test/scala/org/apache/pekko/grpc/internal/ClientTimeoutHeaderSpec.scala
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.pekko.grpc.internal
+
+import java.util.concurrent.TimeUnit
+import scala.concurrent.duration._
+
+import io.grpc.{ CallOptions, Deadline }
+import org.apache.pekko.grpc.scaladsl.headers.`Timeout`
+import org.scalatest.OptionValues
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+/**
+ * `applyDeadline` only bounds the wait on the client side. Without `grpc-timeout` on the wire
+ * the server has no way to know there is a deadline at all.
+ */
+class ClientTimeoutHeaderSpec extends AnyWordSpec with Matchers with OptionValues {
+
+  "The pekko-http client" should {
+
+    "send grpc-timeout when the call has a deadline" in {
+      val options = CallOptions.DEFAULT.withDeadline(Deadline.after(5, TimeUnit.SECONDS))
+
+      val sent = PekkoHttpClientUtils.timeoutHeader(options)
+
+      sent should have size 1
+      // some of the budget is spent building the request, so allow for a little drift
+      val requested = `Timeout`.findIn(sent.toIndexedSeq).value
+      requested should be <= 5.seconds
+      requested should be > 4.seconds
+    }
+
+    "send no grpc-timeout when the call has no deadline" in {
+      PekkoHttpClientUtils.timeoutHeader(CallOptions.DEFAULT) shouldBe empty
+    }
+
+    "send no grpc-timeout when the deadline has already expired" in {
+      // such a call is failed outright rather than sent, and a non-positive timeout is not
+      // representable on the wire
+      val expired = CallOptions.DEFAULT.withDeadline(Deadline.after(-1, TimeUnit.SECONDS))
+
+      PekkoHttpClientUtils.timeoutHeader(expired) shouldBe empty
+    }
+  }
+}

--- a/runtime/src/test/scala/org/apache/pekko/grpc/scaladsl/ServerDeadlineSpec.scala
+++ b/runtime/src/test/scala/org/apache/pekko/grpc/scaladsl/ServerDeadlineSpec.scala
@@ -1,0 +1,116 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.pekko.grpc.scaladsl
+
+import scala.concurrent.{ ExecutionContext, Future, Promise }
+import scala.concurrent.duration._
+
+import io.grpc.Status
+import org.apache.pekko
+import pekko.actor.ActorSystem
+import pekko.grpc.GrpcProtocol.GrpcProtocolWriter
+import pekko.grpc.internal.{ GrpcProtocolNative, Identity }
+import pekko.grpc.scaladsl.headers.`Timeout`
+import pekko.http.scaladsl.model.{ HttpRequest, HttpResponse, StatusCodes }
+import pekko.http.scaladsl.model.headers.RawHeader
+import pekko.testkit.TestKit
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.time.Span
+import org.scalatest.wordspec.AnyWordSpecLike
+
+/**
+ * A client stops waiting once its own deadline expires, so without a server-side deadline the
+ * server keeps working on a reply nobody is going to read.
+ */
+class ServerDeadlineSpec
+    extends TestKit(ActorSystem("ServerDeadlineSpec"))
+    with AnyWordSpecLike
+    with Matchers
+    with ScalaFutures
+    with BeforeAndAfterAll {
+
+  implicit val patience: PatienceConfig =
+    PatienceConfig(10.seconds, Span(50, org.scalatest.time.Millis))
+  implicit val ec: ExecutionContext = system.dispatcher
+  implicit val writer: GrpcProtocolWriter = GrpcProtocolNative.newWriter(Identity)
+
+  private def statusOf(response: HttpResponse): Option[String] =
+    response.headers.collectFirst { case h if h.is("grpc-status") => h.value }
+
+  "withServerDeadline" should {
+
+    "leave a request with no grpc-timeout unbounded" in {
+      val request = HttpRequest()
+      val slow = pekko.pattern.after(300.millis)(Future.successful(HttpResponse()))(system)
+
+      val response = GrpcMarshalling.withServerDeadline(request, slow).futureValue
+
+      response.status shouldBe StatusCodes.OK
+      statusOf(response) shouldBe None
+    }
+
+    "complete a response that beats the deadline unchanged" in {
+      val request = HttpRequest().withHeaders(`Timeout`(5.seconds))
+
+      val response = GrpcMarshalling.withServerDeadline(request, Future.successful(HttpResponse())).futureValue
+
+      response.status shouldBe StatusCodes.OK
+      statusOf(response) shouldBe None
+    }
+
+    "fail a response that misses the deadline with DEADLINE_EXCEEDED" in {
+      val request = HttpRequest().withHeaders(`Timeout`(100.millis))
+      // never completes, standing in for a handler that outlives the client
+      val stuck = Promise[HttpResponse]().future
+
+      val response = GrpcMarshalling.withServerDeadline(request, stuck).futureValue
+
+      statusOf(response) shouldBe Some(Status.Code.DEADLINE_EXCEEDED.value.toString)
+    }
+
+    "not wait for the handler once the deadline has passed" in {
+      val request = HttpRequest().withHeaders(`Timeout`(100.millis))
+      val slow = pekko.pattern.after(5.seconds)(Future.successful(HttpResponse()))(system)
+
+      val started = System.nanoTime()
+      val response = GrpcMarshalling.withServerDeadline(request, slow).futureValue
+      val elapsed = (System.nanoTime() - started).nanos
+
+      statusOf(response) shouldBe Some(Status.Code.DEADLINE_EXCEEDED.value.toString)
+      withClue(s"returned after $elapsed: ") {
+        elapsed should be < 5.seconds
+      }
+    }
+
+    "ignore a malformed grpc-timeout rather than refusing to serve" in {
+      val request = HttpRequest().withHeaders(RawHeader("grpc-timeout", "not a timeout"))
+
+      val response = GrpcMarshalling.withServerDeadline(request, Future.successful(HttpResponse())).futureValue
+
+      response.status shouldBe StatusCodes.OK
+      statusOf(response) shouldBe None
+    }
+  }
+
+  override def afterAll(): Unit = {
+    TestKit.shutdownActorSystem(system)
+    super.afterAll()
+  }
+}

--- a/runtime/src/test/scala/org/apache/pekko/grpc/scaladsl/headers/TimeoutSpec.scala
+++ b/runtime/src/test/scala/org/apache/pekko/grpc/scaladsl/headers/TimeoutSpec.scala
@@ -1,0 +1,116 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.pekko.grpc.scaladsl.headers
+
+import scala.collection.immutable
+import scala.concurrent.duration._
+
+import org.apache.pekko.http.scaladsl.model.headers.RawHeader
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+/**
+ * The `grpc-timeout` wire format is a positive integer of at most 8 digits followed by a unit
+ * character: https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md
+ */
+class TimeoutSpec extends AnyWordSpec with Matchers {
+
+  "Timeout.parse" should {
+
+    "read each unit the protocol defines" in {
+      `Timeout`.parse("3H").get.timeout shouldBe 3.hours
+      `Timeout`.parse("5M").get.timeout shouldBe 5.minutes
+      `Timeout`.parse("10S").get.timeout shouldBe 10.seconds
+      `Timeout`.parse("500m").get.timeout shouldBe 500.millis
+      `Timeout`.parse("250u").get.timeout shouldBe 250.micros
+      `Timeout`.parse("100n").get.timeout shouldBe 100.nanos
+    }
+
+    "read the largest value the wire format allows" in {
+      `Timeout`.parse("99999999S").get.timeout shouldBe 99999999.seconds
+    }
+
+    "reject a value with more than 8 digits" in {
+      `Timeout`.parse("999999999S").isFailure shouldBe true
+    }
+
+    "reject an unknown unit" in {
+      `Timeout`.parse("10X").isFailure shouldBe true
+    }
+
+    "reject a value that is too short to carry a unit" in {
+      `Timeout`.parse("S").isFailure shouldBe true
+      `Timeout`.parse("").isFailure shouldBe true
+    }
+
+    "reject a non-numeric amount" in {
+      `Timeout`.parse("abcS").isFailure shouldBe true
+    }
+  }
+
+  "Timeout.value" should {
+
+    "use nanoseconds while they fit in 8 digits" in {
+      `Timeout`(50.millis).value() shouldBe "50000000n"
+    }
+
+    "fall back to coarser units as the value grows" in {
+      // 1 second is 1e9 nanoseconds, which needs 10 digits
+      `Timeout`(1.second).value() shouldBe "1000000u"
+      `Timeout`(10.minutes).value() shouldBe "600000m"
+      `Timeout`(2.hours).value() shouldBe "7200000m"
+      // 30 days is 2_592_000_000 ms (10 digits) but 2_592_000 s (7), so seconds win
+      `Timeout`(30.days).value() shouldBe "2592000S"
+      // and past that, minutes: 2000 days is 172_800_000 s (9 digits) but 2_880_000 min (7)
+      `Timeout`(2000.days).value() shouldBe "2880000M"
+    }
+
+    "round-trip every unit boundary" in {
+      val examples = Seq(1.nano, 100.nanos, 1.milli, 50.millis, 1.second, 90.seconds, 10.minutes, 2.hours, 30.days)
+
+      examples.foreach { d =>
+        val encoded = `Timeout`(d).value()
+        withClue(s"$d encoded as $encoded: ") {
+          encoded.length - 1 should be <= 8
+          // coarser units truncate, so the decoded value must not exceed the original
+          val decoded = `Timeout`.parse(encoded).get.timeout
+          decoded should be <= d
+          decoded.toMillis.toDouble shouldBe d.toMillis.toDouble +- (d.toMillis * 0.001 + 1)
+        }
+      }
+    }
+  }
+
+  "Timeout.findIn" should {
+
+    "find a timeout among other headers" in {
+      val hs = immutable.Seq(RawHeader("other", "value"), RawHeader("grpc-timeout", "250m"))
+
+      `Timeout`.findIn(hs) shouldBe Some(250.millis)
+    }
+
+    "return None when there is no timeout" in {
+      `Timeout`.findIn(immutable.Seq(RawHeader("other", "value"))) shouldBe None
+    }
+
+    "ignore a malformed value rather than failing the request" in {
+      // the timeout is a hint from the peer; refusing to serve the request would be worse
+      `Timeout`.findIn(immutable.Seq(RawHeader("grpc-timeout", "not a timeout"))) shouldBe None
+    }
+  }
+}


### PR DESCRIPTION
### Motivation

`grpc-timeout` appeared in this repository in exactly one place — the gRPC-Web CORS
allow-list. Nothing parsed it, so a server kept working on a reply the client had
already given up on: the client stops waiting when its own deadline expires, and
the server was never told there was one.

The pekko-http client made that worse by never sending the header. `applyDeadline`
bounded the wait on the client side only, so a server talking to it had no way to
learn of a deadline at all. The netty client sends it via grpc-java's `GrpcUtil`,
so this was a gap on both the server and the pekko-http client.

### Modification

**Header model** — `grpc-timeout` is a positive integer of at most 8 digits followed
by a unit character, per
[PROTOCOL-HTTP2](https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md).
Rendering picks the finest unit whose value still fits in 8 digits, so precision is
kept for short deadlines and long ones still encode.

**Server** — `GrpcMarshalling.withServerDeadline` bounds a response by the requested
deadline, completing with `DEADLINE_EXCEEDED` on expiry — the same status the client
reports for the same call. Generated Scala and Java handlers apply it *inside* the
existing `negotiatedWithMaxSize` block, so the protocol writer is already in scope
and the request is not negotiated twice.

**Client** — the pekko-http backend now sends `grpc-timeout` derived from
`CallOptions`. An already-expired deadline sends nothing: such a call is failed
outright by `applyDeadline`, and a non-positive timeout is not representable on the
wire.

A malformed value is ignored rather than rejected. The timeout is a hint from the
peer, and refusing to serve the request would be a worse outcome than serving it
without a deadline.

### Result

A server stops producing a response once the client's deadline has passed, and both
backends now tell the server what that deadline is.

### Tests

- `TimeoutSpec` — every unit, the 8-digit cap, malformed values, and that encoding
  round-trips without ever exceeding the original duration
- `ServerDeadlineSpec` — the enforcement helper, including that it returns well
  before a slow handler would have
- `ClientTimeoutHeaderSpec` — what the client actually puts on the wire
- `ServerTimeoutSpec` — drives a generated handler end to end, so the codegen wiring
  is covered and not just the helper it calls. It asserts the service was entered,
  so a pass cannot come from a routing miss

Confirmed the guard bites: with the deadline never applied, 2 tests fail.

- `sbt "runtime/testOnly ...ServerDeadlineSpec ...ClientTimeoutHeaderSpec ...TimeoutSpec"` — 20 passed
- `sbt "plugin-tester-scala/testOnly ...ServerTimeoutSpec"` — 2 passed
- `sbt "plugin-tester-scala/Test/compile" "plugin-tester-java/Test/compile" "interop-tests/Test/compile"` — passed
- `sbt "runtime/mimaReportBinaryIssues"` — passed
- `sbt scalafmtAll scalafmtSbt` — applied
- `sbt "runtime/test"` (full suite) — not run locally, left to CI

### Notes

The deadline bounds the **response**, not the work behind it. A service that has
already started an expensive operation keeps running it; only the reply is
abandoned. Stopping the work itself needs the service to observe cancellation of
the `Future` or `Source` it returned. Documented in `server/details.md`.

Handlers generated before this change do not call `withServerDeadline`, so they
keep the current behaviour until regenerated — the same regeneration caveat #818
carries.

Built on top of #818, which is now merged; this branch is rebased onto it and
contains only the timeout change.
