### PR TITLE
Pass GrpcServerSettings to the negotiate entry points

### DIFF
--- a/benchmarks/src/main/scala/org/apache/pekko/grpc/JavaUnaryHandlerBenchmark.scala
+++ b/benchmarks/src/main/scala/org/apache/pekko/grpc/JavaUnaryHandlerBenchmark.scala
@@ -93,7 +93,7 @@ class JavaUnaryHandlerBenchmark extends CommonBenchmark {
   private val generatedStyleHandler: JHttpRequest => CompletionStage[JHttpResponse] =
     request =>
       JGrpcMarshalling
-        .negotiated[JHttpResponse](
+        .negotiated(
           request,
           (reader, writer) => {
             request.entity() match {
@@ -124,7 +124,7 @@ class JavaUnaryHandlerBenchmark extends CommonBenchmark {
   private val oldStyleHandler: JHttpRequest => CompletionStage[JHttpResponse] =
     request =>
       JGrpcMarshalling
-        .negotiated[JHttpResponse](
+        .negotiated(
           request,
           (reader, writer) =>
             JGrpcMarshalling

--- a/codegen/src/main/twirl/templates/JavaServer/Handler.scala.txt
+++ b/codegen/src/main/twirl/templates/JavaServer/Handler.scala.txt
@@ -157,15 +157,13 @@ public class @{serviceName}HandlerFactory {
      */
     public static Function<org.apache.pekko.http.javadsl.model.HttpRequest, CompletionStage<org.apache.pekko.http.javadsl.model.HttpResponse>> partial(@serviceName implementation, String prefix, Materializer mat, org.apache.pekko.japi.function.Function<ActorSystem, org.apache.pekko.japi.function.Function<Throwable, Trailers>> eHandler, GrpcServerSettings settings, ClassicActorSystemProvider system) {
       TelemetrySpi spi = TelemetryExtension.get(system).spi();
-      // resolved once, outside the returned function, so config is not re-read per request
-      int maxInboundMessageSize = settings.maxInboundMessageSize();
       return (req -> {
         Iterator<String> segments = req.getUri().pathSegments().iterator();
         if (segments.hasNext() && segments.next().equals(prefix) && segments.hasNext()) {
           String method = segments.next();
           if (segments.hasNext()) return notFound; // we don't allow any random `/prefix/Method/anything/here
           else {
-            return handle(spi.onRequest(prefix, method, req), method, implementation, mat, eHandler, maxInboundMessageSize, system);
+            return handle(spi.onRequest(prefix, method, req), method, implementation, mat, eHandler, settings, system);
           }
         } else {
           return notFound;
@@ -177,8 +175,8 @@ public class @{serviceName}HandlerFactory {
       return @{service.name}.name;
     }
 
-    private static CompletionStage<org.apache.pekko.http.javadsl.model.HttpResponse> handle(org.apache.pekko.http.javadsl.model.HttpRequest request, String method, @serviceName implementation, Materializer mat, org.apache.pekko.japi.function.Function<ActorSystem, org.apache.pekko.japi.function.Function<Throwable, Trailers>> eHandler, int maxInboundMessageSize, ClassicActorSystemProvider system) {
-      return GrpcMarshalling.negotiatedWithMaxSize(request, maxInboundMessageSize, (reader, writer) -> {
+    private static CompletionStage<org.apache.pekko.http.javadsl.model.HttpResponse> handle(org.apache.pekko.http.javadsl.model.HttpRequest request, String method, @serviceName implementation, Materializer mat, org.apache.pekko.japi.function.Function<ActorSystem, org.apache.pekko.japi.function.Function<Throwable, Trailers>> eHandler, GrpcServerSettings settings, ClassicActorSystemProvider system) {
+      return GrpcMarshalling.negotiated(request, settings, (reader, writer) -> {
         CompletionStage<org.apache.pekko.http.javadsl.model.HttpResponse> response;
         @{if(powerApis) { "Metadata metadata = MetadataBuilder.fromHeaders(request.getHeaders());" } else { "" }}
         switch(method) {

--- a/codegen/src/main/twirl/templates/ScalaServer/Handler.scala.txt
+++ b/codegen/src/main/twirl/templates/ScalaServer/Handler.scala.txt
@@ -117,7 +117,7 @@ object @{serviceName}Handler {
 
     private def handler(implementation: @serviceName, prefix: String, eHandler: ActorSystem => PartialFunction[Throwable, Trailers], settings: Option[GrpcServerSettings] = None)(@{service.scalaCompatConstants.ImplicitParameter} system: ClassicActorSystemProvider): model.HttpRequest => scala.concurrent.Future[model.HttpResponse] = {
       // resolved once, outside the returned function, so config is not re-read per request
-      val maxInboundMessageSize = settings.getOrElse(GrpcServerSettings.create(system)).maxInboundMessageSize
+      val serverSettings = settings.getOrElse(GrpcServerSettings.create(system))
       @{service.scalaCompatConstants.ImplicitVal} mat: Materializer = SystemMaterializer(system).materializer
       @{service.scalaCompatConstants.ImplicitVal} ec: ExecutionContext = mat.executionContext
       val spi = TelemetryExtension(system).spi
@@ -125,7 +125,7 @@ object @{serviceName}Handler {
       import @{service.name}.Serializers.@{service.scalaCompatConstants.WildcardImport}
 
       def handle(request: model.HttpRequest, method: String): scala.concurrent.Future[model.HttpResponse] =
-        GrpcMarshalling.negotiatedWithMaxSize(request, maxInboundMessageSize, (reader, writer) =>
+        GrpcMarshalling.negotiated(request, serverSettings, (reader, writer) =>
           method match {
             @for(method <- service.methods) {
             case "@method.grpcName" =>
@@ -162,7 +162,7 @@ object @{serviceName}Handler {
      */
     def partial(implementation: @serviceName, prefix: String = @{service.name}.name, eHandler: ActorSystem => PartialFunction[Throwable, Trailers] = GrpcExceptionHandler.defaultMapper, settings: Option[GrpcServerSettings] = None)(@{service.scalaCompatConstants.ImplicitParameter} system: ClassicActorSystemProvider): PartialFunction[model.HttpRequest, scala.concurrent.Future[model.HttpResponse]] = {
       // resolved once, outside the returned partial function, so config is not re-read per request
-      val maxInboundMessageSize = settings.getOrElse(GrpcServerSettings.create(system)).maxInboundMessageSize
+      val serverSettings = settings.getOrElse(GrpcServerSettings.create(system))
       @{service.scalaCompatConstants.ImplicitVal} mat: Materializer = SystemMaterializer(system).materializer
       @{service.scalaCompatConstants.ImplicitVal} ec: ExecutionContext = mat.executionContext
       val spi = TelemetryExtension(system).spi
@@ -170,7 +170,7 @@ object @{serviceName}Handler {
       import @{service.name}.Serializers.@{service.scalaCompatConstants.WildcardImport}
 
       def handle(request: model.HttpRequest, method: String): scala.concurrent.Future[model.HttpResponse] =
-        GrpcMarshalling.negotiatedWithMaxSize(request, maxInboundMessageSize, (reader, writer) =>
+        GrpcMarshalling.negotiated(request, serverSettings, (reader, writer) =>
           method match {
             @for(method <- service.methods) {
             case "@method.grpcName" =>

--- a/runtime/src/main/scala/org/apache/pekko/grpc/GrpcProtocol.scala
+++ b/runtime/src/main/scala/org/apache/pekko/grpc/GrpcProtocol.scala
@@ -157,20 +157,20 @@ object GrpcProtocol {
    * @return the protocol reader for the request, and a protocol writer for the response.
    */
   def negotiate(request: jmodel.HttpRequest): Option[(Try[GrpcProtocolReader], GrpcProtocolWriter)] =
-    negotiate(request, AbstractGrpcProtocol.DefaultMaxInboundMessageSize)
+    negotiate(request, GrpcServerSettings.defaults)
 
   /**
    * Calculates the gRPC protocol encoding to use for an interaction with a gRPC client.
    *
    * @param request the client request to respond to.
-   * @param maxInboundMessageSize the maximum allowed inbound message size in bytes.
+   * @param settings the settings of the server handling the request.
    * @return the protocol reader for the request, and a protocol writer for the response.
    */
   def negotiate(
       request: jmodel.HttpRequest,
-      maxInboundMessageSize: Int): Option[(Try[GrpcProtocolReader], GrpcProtocolWriter)] =
+      settings: GrpcServerSettings): Option[(Try[GrpcProtocolReader], GrpcProtocolWriter)] =
     detect(request).map { variant =>
-      (Codecs.detect(request).map(variant.newReader(_, maxInboundMessageSize)),
+      (Codecs.detect(request).map(variant.newReader(_, settings.maxInboundMessageSize)),
         variant.newWriter(Codecs.negotiate(request)))
     }
 

--- a/runtime/src/main/scala/org/apache/pekko/grpc/GrpcServerSettings.scala
+++ b/runtime/src/main/scala/org/apache/pekko/grpc/GrpcServerSettings.scala
@@ -11,11 +11,19 @@ package org.apache.pekko.grpc
 
 import org.apache.pekko
 import pekko.actor.ClassicActorSystemProvider
-import pekko.annotation.ApiMayChange
+import pekko.annotation.{ ApiMayChange, InternalApi }
 import pekko.grpc.internal.AbstractGrpcProtocol
-import com.typesafe.config.Config
+import com.typesafe.config.{ Config, ConfigFactory }
 
 object GrpcServerSettings {
+
+  /**
+   * INTERNAL API
+   *
+   * The built-in defaults, for entry points that have no access to the actor system's configuration.
+   */
+  @InternalApi
+  private[grpc] lazy val defaults: GrpcServerSettings = fromConfig(ConfigFactory.empty())
 
   /**
    * Scala API: Create settings from the actor system's default configuration (`pekko.grpc.server`).

--- a/runtime/src/main/scala/org/apache/pekko/grpc/javadsl/GrpcMarshalling.scala
+++ b/runtime/src/main/scala/org/apache/pekko/grpc/javadsl/GrpcMarshalling.scala
@@ -38,29 +38,20 @@ object GrpcMarshalling {
   def negotiated[T](
       req: HttpRequest,
       f: (GrpcProtocolReader, GrpcProtocolWriter) => CompletionStage[T]): Optional[CompletionStage[T]] =
-    GrpcProtocol
-      .negotiate(req)
-      .map {
-        case (maybeReader, writer) =>
-          maybeReader.map(reader => f(reader, writer)).fold[CompletionStage[T]](failure, identity)
-      }
-      .fold(Optional.empty[CompletionStage[T]])(Optional.of)
+    negotiated(req, GrpcServerSettings.defaults, f)
 
   /**
-   * INTERNAL API
+   * Negotiates the gRPC protocol for a server handler with the given settings.
    *
-   * Negotiates the gRPC protocol with a custom maximum inbound message size.
-   *
-   * Deliberately not an overload of `negotiated`: a second overload would stop Scala from
-   * inferring the parameter types of the `(reader, writer) => ...` lambda at existing call sites.
+   * The settings carry the handler-scoped configuration (currently the maximum inbound
+   * message size), so that further configuration can be added without another entry point here.
    */
-  @InternalApi
-  def negotiatedWithMaxSize[T](
+  def negotiated[T](
       req: HttpRequest,
-      maxInboundMessageSize: Int,
+      settings: GrpcServerSettings,
       f: (GrpcProtocolReader, GrpcProtocolWriter) => CompletionStage[T]): Optional[CompletionStage[T]] =
     GrpcProtocol
-      .negotiate(req, maxInboundMessageSize)
+      .negotiate(req, settings)
       .map {
         case (maybeReader, writer) =>
           maybeReader.map(reader => f(reader, writer)).fold[CompletionStage[T]](failure, identity)

--- a/runtime/src/main/scala/org/apache/pekko/grpc/scaladsl/GrpcMarshalling.scala
+++ b/runtime/src/main/scala/org/apache/pekko/grpc/scaladsl/GrpcMarshalling.scala
@@ -55,27 +55,21 @@ object GrpcMarshalling {
   }
 
   def negotiated[T](req: HttpRequest, f: (GrpcProtocolReader, GrpcProtocolWriter) => Future[T]): Option[Future[T]] =
-    GrpcProtocol.negotiate(req).map {
-      case (Success(reader), writer) => f(reader, writer)
-      case (Failure(ex), _)          => FastFuture.failed(ex)
-    }
+    negotiated(req, GrpcServerSettings.defaults, f)
 
   /**
-   * INTERNAL API
+   * Negotiates the gRPC protocol for a server handler with the given settings.
    *
-   * Negotiates the gRPC protocol with a custom maximum inbound message size.
-   *
-   * Deliberately not an overload of `negotiated`: a second overload would stop Scala from
-   * inferring the parameter types of the `(reader, writer) => ...` lambda at existing call sites.
+   * The settings carry the handler-scoped configuration (currently the maximum inbound
+   * message size), so that further configuration can be added without another entry point here.
    */
-  @InternalApi
-  def negotiatedWithMaxSize[T](
+  def negotiated[T](
       req: HttpRequest,
-      maxInboundMessageSize: Int,
+      settings: GrpcServerSettings,
       f: (GrpcProtocolReader, GrpcProtocolWriter) => Future[T]): Option[Future[T]] =
-    GrpcProtocol.negotiate(req, maxInboundMessageSize).map {
+    GrpcProtocol.negotiate(req, settings).map {
       case (Success(reader), writer) => f(reader, writer)
-      case (Failure(ex), _)          => Future.failed(ex)
+      case (Failure(ex), _)          => FastFuture.failed(ex)
     }
 
   def unmarshal[T](data: Source[ByteString, Any])(

--- a/runtime/src/test/scala/org/apache/pekko/grpc/GrpcMarshallingNegotiationSpec.scala
+++ b/runtime/src/test/scala/org/apache/pekko/grpc/GrpcMarshallingNegotiationSpec.scala
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.pekko.grpc
+
+import java.util.concurrent.{ CompletableFuture, TimeUnit }
+
+import scala.concurrent.Future
+
+import io.grpc.{ Status, StatusException }
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
+
+import org.apache.pekko
+import pekko.actor.ActorSystem
+import pekko.grpc.GrpcProtocol.GrpcProtocolReader
+import pekko.grpc.internal.{ AbstractGrpcProtocol, GrpcProtocolNative }
+import pekko.http.scaladsl.model.{ HttpEntity, HttpRequest }
+import pekko.testkit.TestKit
+import pekko.util.ByteString
+
+class GrpcMarshallingNegotiationSpec extends TestKit(ActorSystem()) with AnyWordSpecLike with Matchers {
+
+  private val Limit = 64 * 1024
+
+  private val request =
+    HttpRequest(entity = HttpEntity.Strict(GrpcProtocolNative.contentType, ByteString.empty))
+
+  /** A frame header: 1 byte flags + 4 bytes big-endian length. */
+  private def frameHeader(length: Int): ByteString =
+    ByteString(0.toByte, (length >>> 24).toByte, (length >>> 16).toByte, (length >>> 8).toByte, length.toByte)
+
+  private def scalaReader(negotiated: Option[Future[GrpcProtocolReader]]): GrpcProtocolReader =
+    negotiated.flatMap(_.value).get.get
+
+  private def javaReader(
+      negotiated: java.util.Optional[java.util.concurrent.CompletionStage[GrpcProtocolReader]]): GrpcProtocolReader =
+    negotiated.get.toCompletableFuture.get(3, TimeUnit.SECONDS)
+
+  /** The readers the two DSLs negotiate for `settings`. */
+  private def readers(settings: GrpcServerSettings): Seq[GrpcProtocolReader] =
+    Seq(
+      scalaReader(scaladsl.GrpcMarshalling.negotiated(request, settings, (reader, _) => Future.successful(reader))),
+      javaReader(
+        javadsl.GrpcMarshalling.negotiated(request, settings,
+          (reader, _) => CompletableFuture.completedFuture(reader))))
+
+  /** The readers the two DSLs negotiate when no settings are passed. */
+  private def defaultReaders(): Seq[GrpcProtocolReader] =
+    Seq(
+      scalaReader(scaladsl.GrpcMarshalling.negotiated(request, (reader, _) => Future.successful(reader))),
+      javaReader(
+        javadsl.GrpcMarshalling.negotiated(request, (reader, _) => CompletableFuture.completedFuture(reader))))
+
+  private def frame(size: Int): ByteString = {
+    val data = ByteString(new Array[Byte](size))
+    frameHeader(size) ++ data
+  }
+
+  "GrpcMarshalling.negotiated" should {
+
+    "build a reader bounded by the settings' maximum inbound message size" in {
+      val settings = GrpcServerSettings(system).withMaxInboundMessageSize(Limit)
+
+      readers(settings).foreach { reader =>
+        val status = intercept[StatusException](reader.decodeSingleFrame(frame(Limit + 1))).getStatus
+
+        status.getCode shouldBe Status.Code.RESOURCE_EXHAUSTED
+        status.getDescription should include(s"Frame length ${Limit + 1}")
+      }
+    }
+
+    "build a reader bounded by the built-in default when no settings are passed" in {
+      defaultReaders().foreach { reader =>
+        // the frame the bounded settings above reject is accepted here, so the limit really
+        // comes from the settings rather than from a value baked into the negotiation
+        reader.decodeSingleFrame(frame(Limit + 1)).size shouldBe (Limit + 1)
+
+        val tooLarge = AbstractGrpcProtocol.DefaultMaxInboundMessageSize + 1
+        intercept[StatusException](
+          reader.decodeSingleFrame(frameHeader(tooLarge))).getStatus.getCode shouldBe Status.Code.RESOURCE_EXHAUSTED
+      }
+    }
+  }
+}


### PR DESCRIPTION
### Motivation
[#818](https://github.com/apache/pekko-grpc/pull/818) added a `GrpcMarshalling.negotiatedWithMaxSize` entry point that takes a maximum inbound message size, and #747 proposes another `negotiate` variant for compression. One entry point per setting does not scale, and each new one also changes the generated handlers.

This is a prototype of the consolidation asked for in #875, using `GrpcServerSettings` as the object that is passed in rather than a new `ServerHandlerContext`.

### Modification
- `GrpcProtocol.negotiate` and `GrpcMarshalling.negotiated` (scaladsl and javadsl) take a `GrpcServerSettings` instead of an `Int`, as an overload of `negotiated` rather than under a separate name. `negotiatedWithMaxSize` is removed — it was `@InternalApi` and unreleased.
- The settings-less forms delegate to the new overload with `GrpcServerSettings.defaults` (package-private, built from an empty `Config` so it carries the built-in values).
- The Scala and Java handler templates resolve their settings once and pass them straight through, instead of unpacking `maxInboundMessageSize`. The generated `partial` signatures keep their existing `GrpcServerSettings` parameter, so the public surface and the docs from #818 are unchanged.
- `JavaUnaryHandlerBenchmark` lets `T` be inferred: the javadsl overload does not resolve when a Scala caller applies an explicit type argument (`negotiated[JHttpResponse](req, lambda)` fails with "missing parameter type"). Ordinary Scala call sites and Java callers are unaffected — arity prunes the alternatives.

### Result
Further server handler configuration is added to `GrpcServerSettings` rather than as another negotiate entry point and another generated-handler parameter. If #875 settles on a richer `ServerHandlerContext` (settings plus interceptors, `Metadata` attributes), swapping it in is a one-line change at each call site, since both entry points already take a single object.

### Tests
- `sbt "runtime/testOnly org.apache.pekko.grpc.*"` — 174 passed, including the new `GrpcMarshallingNegotiationSpec`, which asserts the negotiated reader is bounded by the settings passed (both DSLs) and that the settings-less form still gets the 4 MiB default. It uses a frame the bounded settings reject and the default accepts, so it cannot pass on a hardcoded limit.
- `sbt "runtime/mimaReportBinaryIssues"` — passed
- `sbt "runtime/Test/compile" "benchmarks/Test/compile" "plugin-tester-scala/Test/compile" "plugin-tester-java/Test/compile" "interop-tests/Test/compile"` — passed
- `sbt "++3.3.8 runtime/Test/compile" "++3.3.8 plugin-tester-scala/Test/compile" "++3.3.8 benchmarks/Test/compile"` — passed

### References
Refs #875, Refs #818, Refs #747