### PR TITLE
Drop stray $ from PekkoHttpServerProviderJava test object name

### DIFF
--- a/interop-tests/src/test/scala/org/apache/pekko/grpc/interop/GrpcInteropSpec.scala
+++ b/interop-tests/src/test/scala/org/apache/pekko/grpc/interop/GrpcInteropSpec.scala
@@ -50,7 +50,7 @@ class GrpcInteropPekkoJavaWithPekkoHttpJavaSpec extends GrpcInteropTests(Servers
 object Servers {
   val IoGrpc = IoGrpcJavaServerProvider
   object Pekko {
-    val Java = PekkoHttpServerProviderJava$
+    val Java = PekkoHttpServerProviderJava
     val Scala = PekkoHttpServerProviderScala
   }
 }
@@ -73,7 +73,7 @@ object Clients {
 
 //--- Some more providers
 
-object PekkoHttpServerProviderJava$ extends PekkoHttpServerProvider {
+object PekkoHttpServerProviderJava extends PekkoHttpServerProvider {
   val label: String = "pekko-grpc java server"
 
   val pendingCases =


### PR DESCRIPTION
### Motivation

Scala 3.9.0 added syntax warning `E230`, which flags identifiers containing `$` as reserved for internal compiler use. The `interop-tests` test sources are compiled with `-Werror`, so `object PekkoHttpServerProviderJava$` turns that warning into a build failure:

```
-- [E230] Syntax Warning: interop-tests/src/test/scala/org/apache/pekko/grpc/interop/GrpcInteropSpec.scala:76:7
76 |object PekkoHttpServerProviderJava$ extends PekkoHttpServerProvider {
   |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |The identifier `PekkoHttpServerProviderJava$` should not contain `$`, which is reserved for internal compiler use.
[error] No warnings can be incurred under -Werror
```

The trailing `$` is not intentional. It is a leftover from the Akka to Pekko rename in 7ad0b5d6 — the equivalent object in the sbt scripted test copy of this spec (`sbt-plugin/src/sbt-test/gen-scala-server/00-interop/.../GrpcInteropSpec.scala`) is named `PekkoHttpServerProviderJava` with no `$`.

This is one of two things blocking #881 (bump `scala3Next` to 3.9.0); the other is that the sbt 2.x plugin cannot be built with 3.9.0, which is a separate change.

### Modification

Rename the object to `PekkoHttpServerProviderJava` and update its single reference in `Servers.Pekko.Java`. Both are in the same file and the name is test-only, so nothing outside this spec is affected.

### Result

`interop-tests` test sources compile under Scala 3.9.0 with `-Werror`. Behaviour is unchanged on 2.13 and 3.3 — this is purely a rename.

Note that the `next` CI job on this PR resolves to the current `scala3Next` (3.8.4), so it does not exercise 3.9.0; that verification was done locally, see below.

### Tests

- `sbt -batch "++3.9.0!" interop-tests/Test/compile` — success
- `sbt -batch "++3.9.0!" Test/compile` — success for the whole build, confirming this was the only `E230` occurrence (run on a tree that also carried the sbt-plugin Scala version change that #881 needs)
- `scalafmt --list --mode diff-ref=upstream/main` — no files to reformat

### References

Refs #881